### PR TITLE
Fix Issue compiling lua from main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ libtiff:
 	$(MAKE) -C $@ install
 
 lua:
-	$(MAKE) -C $@ -f makefile.ps2 all
-	$(MAKE) -C $@ -f makefile.ps2 install
+	$(MAKE) -C $@ -f Makefile.ps2 all
+	$(MAKE) -C $@ -f Makefile.ps2 install
 
 # Broken
 madplay: libid3tag libmad


### PR DESCRIPTION
Hello,
There is a typo error in the Main Makefile.
When it is trying to compile the `lua` library is trying to execute a lowercase file but the `lua` make file start with `M` uppercase.

In OS that have case sensitive option, it will fail.

Thanks