### PR TITLE
Fix makefile `all` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKE = make
 
 .PHONY: aalib expat freetype-2.9.1 libconfig-1.4.5 libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer ucl
 
-all: expat freetype-2.4.12 libconfig-1.4.5 zlib libid3tag libjpeg libmad libmikmod libpng libtiff lua romfs sdlgfx sdlttf stlport ucl
+all: expat freetype-2.9.1 libconfig-1.4.5 zlib libid3tag libjpeg libmad libmikmod libpng libtiff lua romfs sdlgfx sdlttf stlport ucl
 
 # Broken
 aalib:


### PR DESCRIPTION
FreeType was updated in e0bca444e875, but the Makefile `all` target was not updated to reflect the change.