### PR TITLE
More makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAKE = make
 
-.PHONY: aalib expat freetype-2.4.12 libconfig-1.4.5 libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer ucl
+.PHONY: aalib expat freetype-2.9.1 libconfig-1.4.5 libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer ucl
 
 all: expat freetype-2.4.12 libconfig-1.4.5 zlib libid3tag libjpeg libmad libmikmod libpng libtiff lua romfs sdlgfx sdlttf stlport ucl
 
@@ -11,7 +11,7 @@ aalib:
 expat:
 	$(MAKE) -C $@ install
 
-freetype-2.4.12:
+freetype-2.9.1:
 	cd $@; ./SetupPS2.sh
 
 libconfig-1.4.5:

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,13 @@ aalib:
 expat:
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean
+	
+freetype: freetype-2.9.1
 
 freetype-2.9.1:
 	cd $@; ./SetupPS2.sh
+
+libconfig: libconfig-1.4.5
 
 libconfig-1.4.5:
 	$(MAKE) -C $@


### PR DESCRIPTION
Added targets freetype and libconfig so users don't have to know which version is currently available in the ports to build it. Will also make it easier for those who wrote tutorials on building the toolchain. It will work when a tutorial follower copies and pastes commands no matter how outdated the tutorial is. It is also just convenient.