### PR TITLE
Transition to more standard toolchain

### DIFF
--- a/Makefile.eeglobal
+++ b/Makefile.eeglobal
@@ -23,11 +23,6 @@ EE_LDFLAGS := -L$(PS2SDK)/ee/lib $(EE_LDFLAGS)
 # Assembler flags
 EE_ASFLAGS := -G0 $(EE_ASFLAGS)
 
-# Link with following libraries.  This is a special case, and instead of
-# allowing the user to override the library order, we always make sure
-# libkernel is the last library to be linked.
-EE_LIBS += -lc -lkernel
-
 # Externally defined variables: EE_BIN, EE_OBJS, EE_LIB
 
 # These macros can be used to simplify certain build rules.
@@ -62,9 +57,8 @@ endif
 %.o: %.s
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 
-$(EE_BIN): $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CFLAGS) \
-		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(CRTI_OBJ) $(CRTBEGIN_OBJ) $(EE_OBJS) $(CRTEND_OBJ) $(CRTN_OBJ) $(EE_LDFLAGS) $(EE_LIBS)
+$(EE_BIN): $(EE_OBJS) $(PS2SDK)
+	$(EE_CC) $(EE_CFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
 
 $(EE_ERL): $(EE_OBJS)
 	$(EE_CC) $(EE_NO_CRT) -o $(EE_ERL) $(EE_OBJS) $(EE_CFLAGS) $(EE_LDFLAGS) -Wl,-r -Wl,-d

--- a/aalib/test/Makefile
+++ b/aalib/test/Makefile
@@ -9,7 +9,7 @@ EE_INCS += -I../include -I$(PS2SDK)/ee/include
 EE_BIN = aafire.elf
 EE_OBJS = aafire.o
 EE_LDFLAGS = -L$(EE_LIB_DIR)
-EE_LIBS = -lc -lkernel $(EE_LIB_DIR)libaa.a -ldebug -lm
+EE_LIBS = $(EE_LIB_DIR)libaa.a
 
 all: $(EE_BIN)
 

--- a/libpng/Makefile
+++ b/libpng/Makefile
@@ -17,9 +17,7 @@ EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
 TEST_OBJS = $(SOURCE_DIR)pngtest.o
 TEST_BIN = pngtest.elf
 TEST_CFLAGS = -I$(PS2SDK)/ports/include -I$(SOURCE_DIR)
-TEST_LIBS = -lz -lm -lc -lkernel
-TEST_LDFLAGS += -mno-crt0
-# TEST_LDFLAGS += -nostartfiles
+TEST_LIBS = -lz
 TEST_LDFLAGS += -L$(PS2SDK)/ee/lib -L$(PS2SDK)/ports/lib $(EE_LIB)
 
 all: pnglibconf.h $(EE_OBJS_DIR) $(EE_LIB_DIR) $(EE_LIB)
@@ -37,9 +35,8 @@ pnglibconf.h: pngusr.h
 	cp ./pngusr.h $(SOURCE_DIR)
 	cd $(SOURCE_DIR) && CPPFLAGS=-DPNG_USER_CONFIG $(MAKE) -f scripts/pnglibconf.mak
 
-$(TEST_BIN) : $(TEST_OBJS) $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CC) -T$(PS2SDK)/ee/startup/linkfile $(TEST_CFLAGS) \
-		-o $(TEST_BIN) $(PS2SDK)/ee/startup/crt0.o $(TEST_OBJS) $(TEST_LDFLAGS) $(TEST_LIBS)
+$(TEST_BIN) : $(TEST_OBJS)
+	$(EE_CC) $(TEST_CFLAGS) -o $(TEST_BIN) $(TEST_OBJS) $(TEST_LDFLAGS) $(TEST_LIBS)
 	cp $(SOURCE_DIR)pngtest.png ./
 
 install: all
@@ -51,7 +48,7 @@ install: all
 	cp -f $(SOURCE_DIR)pnglibconf.h $(DESTDIR)$(PS2SDK)/ports/include
 
 sample: all $(TEST_BIN)
-	
+
 clean:
 	rm -f -r $(SOURCE_DIR)pnglibconf.* $(SOURCE_DIR)pngusr.h $(EE_OBJS_DIR) $(EE_LIB_DIR) $(TEST_BIN) $(TEST_OBJS) pngtest.png pngout.png
 

--- a/lua/etc/Makefile
+++ b/lua/etc/Makefile
@@ -9,10 +9,9 @@ TST= $(TOP)/test
 
 CC= gcc
 CFLAGS= -O2 -Wall -I$(INC) $(MYCFLAGS)
-MYCFLAGS= 
+MYCFLAGS=
 MYLDFLAGS= -Wl,-E
-MYLIBS= -lm
-#MYLIBS= -lm -Wl,-E -ldl -lreadline -lhistory -lncurses
+MYLIBS=
 RM= rm -f
 
 default:

--- a/lua/test/Makefile
+++ b/lua/test/Makefile
@@ -6,7 +6,7 @@ EE_BIN = mini_luap.elf
 
 EE_OBJS = mini_luap.o
 
-EE_LIBS   += -L$(PS2SDK)/ports/lib -L../lib -llua -llualib -lm -lmc
+EE_LIBS   += -L$(PS2SDK)/ports/lib -L../lib -llua -llualib
 EE_INCS   += -I../include -Iinclude -I$(PS2SDK)/ports/include -I../src
 
 all: $(EE_BIN)

--- a/madplay/ee/src/Makefile
+++ b/madplay/ee/src/Makefile
@@ -14,12 +14,12 @@ EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
 EE_OBJS += $(EE_OBJS_DIR)isjpcm_irx.o
 
 EE_LIBS += -lfileXio -ldebug -lmad -lid3tag \
-	-lcdvd -lsjpcm -lz -lm -lgcc -lmc -lc -lmc -lkernel
+	-lcdvd -lsjpcm -lz -lm
 
 EE_CXXFLAGS += -fno-exceptions -fno-rtti
 
 EE_CFLAGS += -DHAVE_STRNCASECMP -DHAVE_CONFIG_H -DHAVE_UNISTD_H \
-	-DHAVE_STRING_H -DHAVE_SYS_TYPES_H 
+	-DHAVE_STRING_H -DHAVE_SYS_TYPES_H
 
 EE_INCS += -I./ -I../include -Iinclude -I$(PS2SDK)/common/include -I$(PS2SDK)/ee/include \
 	-I$(PS2SDK)/ports/include -I$(PS2DEV)/isjpcm/include

--- a/ode/ode/test/Makefile
+++ b/ode/ode/test/Makefile
@@ -15,23 +15,20 @@ BINS = \
 	test_moving_trimesh.elf \
 	test_trimesh.elf \
 	test_step.elf \
-	test_I.elf 
+	test_I.elf
 
 
-OBJS = 
+OBJS =
 EE_INCS += -I../../include
-EE_LIBS += -lode -lopcode -lice -ldrawstuff -lm -ldreamgl -lpad
+EE_LIBS += -lode -lopcode -lice -ldrawstuff -ldreamgl -lpad
 EE_LDFLAGS += -L$(PS2DEV)/dreamgl/lib  -L../../lib
-EE_LDFLAGS += -mno-crt0
-# EE_LDFLAGS += -nostartfiles
 
 all: $(BINS)
 
 install:
 
-%.elf : %.o $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CC) -T$(PS2SDK)/ee/startup/linkfile $(EE_CFLAGS) \
-		-o $@ $(PS2SDK)/ee/startup/crt0.o  $< $(EE_LDFLAGS) $(EE_LIBS)
+%.elf : %.o
+	$(EE_CC) $(EE_CFLAGS) -o $@ $< $(EE_LDFLAGS) $(EE_LIBS)
 	$(EE_STRIP) $@
 
 clean:

--- a/sdl/test/Makefile
+++ b/sdl/test/Makefile
@@ -17,7 +17,7 @@ OBJS = \
 	checkkeys.o
 
 EE_INCS = -I../include
-EE_LIBS = -L. -lc -L$(GSKIT)/lib -L../lib -lsdl -lcdvd
+EE_LIBS = -L. -L$(GSKIT)/lib -L../lib -lsdl -lcdvd
 
 ifneq ("$(wildcard $(GSKIT)/include/gsKit.h)","")
 all: $(BINS)
@@ -28,9 +28,8 @@ endif
 
 install:
 
-%.elf : %.o $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CC) -nostartfiles -T$(PS2SDK)/ee/startup/linkfile $(EE_LDFLAGS) \
-		-o $@ $(PS2SDK)/ee/startup/crt0.o $< $(EE_LIBS)
+%.elf : %.o
+	$(EE_CC) $(EE_LDFLAGS) -o $@ $< $(EE_LIBS)
 
 clean:
 	rm -f $(BINS) $(OBJS)

--- a/sdlgfx/Test/fonts/Makefile
+++ b/sdlgfx/Test/fonts/Makefile
@@ -13,7 +13,7 @@ EE_OBJS = TestFonts.o
 
 EE_INCS = -I../../ -I$(PS2SDK)/ports/include/SDL
 EE_LDFLAGS = -L../../lib/ -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib
-EE_LIBS = -lSDL_gfx -lsdl -lgskit -ldmakit -lm
+EE_LIBS = -lSDL_gfx -lsdl -lgskit -ldmakit
 
 all: $(EE_BIN)
 

--- a/sdlgfx/Test/framerate/Makefile
+++ b/sdlgfx/Test/framerate/Makefile
@@ -13,7 +13,7 @@ EE_OBJS = TestFramerate.o
 
 EE_INCS = -I../../ -I$(PS2SDK)/ports/include/SDL
 EE_LDFLAGS = -L../../lib/ -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib
-EE_LIBS = -lSDL_gfx -lsdl -lgskit -ldmakit -lm
+EE_LIBS = -lSDL_gfx -lsdl -lgskit -ldmakit
 
 all: $(EE_BIN)
 

--- a/sdlgfx/Test/gfxprimitives/Makefile
+++ b/sdlgfx/Test/gfxprimitives/Makefile
@@ -13,7 +13,7 @@ EE_OBJS = TestGfxPrimitives.o
 
 EE_INCS = -I../../ -I$(PS2SDK)/ports/include/SDL
 EE_LDFLAGS = -L../../lib/ -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib
-EE_LIBS = -lSDL_gfx -lsdl -lgskit -ldmakit -lm
+EE_LIBS = -lSDL_gfx -lsdl -lgskit -ldmakit
 
 all: $(EE_BIN)
 

--- a/sdlgfx/Test/rotozoom/Makefile
+++ b/sdlgfx/Test/rotozoom/Makefile
@@ -13,7 +13,7 @@ EE_OBJS = TestRotozoom.o
 
 EE_INCS = -I../../ -I$(PS2SDK)/ports/include/SDL
 EE_LDFLAGS = -L../../lib/ -L$(PS2SDK)/ports/lib -L$(GSKIT)/lib
-EE_LIBS = -lSDL_gfx -lSDL_image -lpng -ljpeg -lz -lsdl -lgskit -ldmakit -lm
+EE_LIBS = -lSDL_gfx -lSDL_image -lpng -ljpeg -lz -lsdl -lgskit -ldmakit
 
 all: $(EE_BIN)
 

--- a/sdlmixer/test/Makefile
+++ b/sdlmixer/test/Makefile
@@ -2,17 +2,14 @@ BINS = sample.elf
 
 EE_CFLAGS = -DUSE_RWOPS
 EE_INCS = -I../include -I$(PS2SDK)/ports/include -I$(PS2SDK)/ports/include/SDL
-EE_LIBS = -L../lib -L$(PS2SDK)/ports/lib -lsdlmixer -lsdl -lc -lm
-EE_LDFLAGS += -mno-crt0
-# EE_LDFLAGS += -nostartfiles
+EE_LIBS = -L../lib -L$(PS2SDK)/ports/lib -lsdlmixer -lsdl
 
 all: $(BINS)
 
 install:
 
-%.elf : %.o $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CXX) -T$(PS2SDK)/ee/startup/linkfile $(EE_LDFLAGS) \
-		-o $@ $(PS2SDK)/ee/startup/crt0.o $< $(EE_LIBS)
+%.elf : %.o
+	$(EE_CXX) $(EE_LDFLAGS) -o $@ $< $(EE_LIBS)
 
 clean:
 	rm -f $(BINS) $(OBJS)

--- a/zlib/Makefile
+++ b/zlib/Makefile
@@ -13,9 +13,7 @@ EE_OBJS := $(EE_OBJS:%=$(EE_OBJS_DIR)%)
 TEST_OBJS = $(SOURCE_DIR)test/example.o
 TEST_BIN = example.elf
 TEST_CFLAGS = -I$(SOURCE_DIR)
-TEST_LIBS = $(EE_LIB) -lc -lkernel
-TEST_LDFLAGS += -mno-crt0
-# TEST_LDFLAGS += -nostartfiles
+TEST_LIBS = $(EE_LIB)
 TEST_LDFLAGS += -L$(PS2SDK)/ee/lib
 
 all: $(EE_OBJS_DIR) $(EE_LIB_DIR) $(EE_LIB)
@@ -29,9 +27,8 @@ $(EE_LIB_DIR):
 $(EE_OBJS_DIR)%.o : $(SOURCE_DIR)%.c
 	$(EE_C_COMPILE) -c $< -o $@
 
-$(TEST_BIN) : $(TEST_OBJS) $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CC) -T$(PS2SDK)/ee/startup/linkfile $(TEST_CFLAGS) \
-		-o $(TEST_BIN) $(PS2SDK)/ee/startup/crt0.o $(TEST_OBJS) $(TEST_LDFLAGS) $(TEST_LIBS)
+$(TEST_BIN) : $(TEST_OBJS)
+	$(EE_CC) $(TEST_CFLAGS) -o $(TEST_BIN) $(TEST_OBJS) $(TEST_LDFLAGS) $(TEST_LIBS)
 	gzip -f -c --best $(TEST_OBJS) > foo.gz
 
 install: all
@@ -42,7 +39,7 @@ install: all
 	cp -f $(SOURCE_DIR)zconf.h $(DESTDIR)$(PS2SDK)/ports/include
 
 sample: all $(TEST_BIN)
-	
+
 clean:
 	rm -f -r $(EE_OBJS_DIR) $(EE_LIB_DIR) $(TEST_OBJS) $(TEST_BIN) foo.gz
 


### PR DESCRIPTION
The ps2toolchain has been updated on april 2018 to be more standard. Special compiler flags and libraries are no longer needed for compiling most applications or libraries. The following can be removed:
- Libraries: libc, libkernel, libm, libmc
- Objects: crt0.o
- Flags: -mno-crt0
- Linkfile

This was also one of the changes that enabled cmake builds of libraries without porting them.

You will need a toolchain compiled after april 2018. I'm hoping the time is right to make these changes. And since you're already testing ps2sdk-ports, I was hoping you can include these changes as well :).