### PR TITLE
Fixed make all when gsKit is not installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .PHONY: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer sdlttf stlport ucl
 
+ifneq ("$(wildcard $(GSKIT)/include/gsKit.h)","")
 all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf ucl
 # libtap stlport ode
+else
+all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay romfs ucl
+# libtap stlport ode
+	@echo "GSKIT not set and gsKit not installed.\nSDL libraries were not built."
+endif
 
 submodules:
 	git submodule init && git submodule update


### PR DESCRIPTION
 While the sdl library checks for gsKit and does not build if it isn't found it does not return an error. Since there is no error make continues, rund make install on sdl, somehow succeeds and then make goes on to try to build sdlimage which than fails with an "'insert object here' is not a member inside the structure or union" error since sdl was not properly built. This was the best solution I could come up with on the fly to resolve #30 but I am sure there is a better one.