### PR TITLE
Added micropython port

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,7 @@
 [submodule "freetype2/src"]
 	path = freetype2/src
 	url = https://git.savannah.gnu.org/git/freetype/freetype2
+[submodule "micropython"]
+	path = micropython
+	url = https://github.com/astrelsky/micropython.git
+	branch = ps2-port

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,9 @@ sdlttf: sdl freetype2
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean
+	
+micropython: submodules
+	cd $@; ./SetupPS2.sh
 
 # Broken
 stlport:


### PR DESCRIPTION
At the moment you can freeze python scripts by running:
`ps2-upython pythonscript.py [output.elf]`

I have yet to do any modules but if you run ps2-upython on the python script in micropython/ports/ps2 and load the elf it will indeed run the script. It only consists of a few print statements, and a for loop.