### PR TITLE
Use EE_AR instead of AR (Mac OS fix)

### DIFF
--- a/sdl/src/Makefile
+++ b/sdl/src/Makefile
@@ -173,7 +173,7 @@ $(LIB_SDL): $(SDL_OBJS)
 	# packing with all embedded libraries
 	rm -rf tmp
 	mkdir tmp
-	$(foreach f, $(EMBEDDED), (cd tmp; $(AR) x $f);)
+	$(foreach f, $(EMBEDDED), (cd tmp; $(EE_AR) x $f);)
 	cp $(SDL_OBJS) tmp
 	$(EE_AR) cru $(LIB_SDL) tmp/*
 	rm -rf tmp


### PR DESCRIPTION
AR doesn't work properly when compiling on Mac, EE_AR gets the job done