### PR TITLE
Move libc from ps2sdk to newlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer sdlttf stlport ucl
 
 ifneq ("$(wildcard $(GSKIT)/include/gsKit.h)","")
-all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf ucl
+all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay sdl sdlgfx sdlimage sdlmixer sdlttf ucl
 # libtap stlport ode
 else
-all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay romfs ucl
+all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtiff lua madplay ucl
 # libtap stlport ode
 	@echo "GSKIT not set and gsKit not installed.\nSDL libraries were not built."
 endif

--- a/libjpeg/src/libjpg.c
+++ b/libjpeg/src/libjpg.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdio.h>
+#include <fcntl.h>
 #include <screenshot.h>
 #include <fileXio_rpc.h>
 

--- a/libmikmod/mmio/mmio_ps2.c
+++ b/libmikmod/mmio/mmio_ps2.c
@@ -67,6 +67,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #include "mikmod_internals.h"
 

--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -31,6 +31,8 @@
  */
 #include "tiffiop.h"
 #include <stdio.h>
+#include <tamtypes.h>
+#include <malloc.h>
 
 static	int gtTileContig(TIFFRGBAImage*, uint32*, uint32, uint32);
 static	int gtTileSeparate(TIFFRGBAImage*, uint32*, uint32, uint32);

--- a/madplay/ee/src/Makefile
+++ b/madplay/ee/src/Makefile
@@ -18,8 +18,8 @@ EE_LIBS += -lfileXio -ldebug -lmad -lid3tag \
 
 EE_CXXFLAGS += -fno-exceptions -fno-rtti
 
-EE_CFLAGS += -DHAVE_STRNCASECMP -DHAVE_CONFIG_H -DHAVE_UNISTD_H \
-	-DHAVE_STRING_H -DHAVE_SYS_TYPES_H
+EE_CFLAGS += -DHAVE_STRNCASECMP -DHAVE_CONFIG_H -DHAVE_UNISTD_H -DHAVE_ERRNO_H \
+	-DHAVE_FCNTL_H -DHAVE_STRING_H -DHAVE_SYS_TYPES_H -DHAVE_ASSERT_H
 
 EE_INCS += -I./ -I../include -Iinclude -I$(PS2SDK)/common/include -I$(PS2SDK)/ee/include \
 	-I$(PS2SDK)/ports/include -I$(PS2DEV)/isjpcm/include

--- a/madplay/ee/src/audio_sjpcm.c
+++ b/madplay/ee/src/audio_sjpcm.c
@@ -23,8 +23,7 @@
 #  include "config.h"
 # endif
 
-# include "global.h"
-
+# include <stdio.h>
 # include <unistd.h>
 # include <errno.h>
 # include <sjpcm.h>
@@ -45,6 +44,8 @@
 #include <sifrpc.h>
 #include <sifcmd.h>
 #include <loadfile.h>
+
+# include "global.h"
 
 typedef void (*functionPointer)();
 

--- a/madplay/ee/src/directory.c
+++ b/madplay/ee/src/directory.c
@@ -199,7 +199,7 @@ int readDirectory(char *ext, int media)
 				ret = fileXioDread(folder.iDir, &directory);
 				if (ret > 0)
 				{
-					if (FIO_S_ISDIR(directory.stat.mode))  //is a directory
+					if (S_ISDIR(directory.stat.mode))  //is a directory
 					{
 						strcpy(folder.object[folder.fIndex].name, "");
 						strcat(folder.object[folder.fIndex].name, "/");
@@ -208,7 +208,7 @@ int readDirectory(char *ext, int media)
 						folder.object[folder.fIndex].count = folder.fIndex;
 						folder.fIndex++;
 					}
-					else if (FIO_S_ISREG(directory.stat.mode)) //is a file
+					else if (S_ISREG(directory.stat.mode)) //is a file
 					{
 						if (size > ret)
 							size = 0;

--- a/madplay/ee/src/madplay.c
+++ b/madplay/ee/src/madplay.c
@@ -23,8 +23,6 @@
 #  include "config.h"
 # endif
 
-# include "global.h"
-
 /* include this first to avoid conflicts with MinGW __argc et al. */
 # include "getopt.h"
 
@@ -54,6 +52,8 @@
 # include "version.h"
 # include "audio.h"
 # include "player.h"
+
+# include "global.h"
 
 # define FADE_DEFAULT	"0:05"
 

--- a/madplay/ee/src/player.c
+++ b/madplay/ee/src/player.c
@@ -23,8 +23,6 @@
 #  include "config.h"
 # endif
 
-# include "global.h"
-
 # include <stdio.h>
 # include <stdarg.h>
 # include <stdlib.h>
@@ -89,6 +87,8 @@
 
 # include "bstdfile.h"
 # include "file.h"
+
+# include "global.h"
 
 # define MPEG_BUFSZ	80000	/* 5.0 s at 128 kbps; 2 s at 320 kbps */
 # define FREQ_TOLERANCE	2	/* percent sampling frequency tolerance */


### PR DESCRIPTION
This pull request is 1 of 5 pull requests in 5 different repositories. The goal of these pull requests is to completely remove libc from ps2sdk, and use newlib's libc. The result is both a much smaller codebase (19k lines removed, 1k lines added), and also will the ps2 development environment be a lot more standard. So porting an application to (or from) the ps2 will be more easy.

The interface between newlib and ps2sdk is now in the old ps2sdk/ee/libc folder, that compiles into libps2sdkc.a. All file io functions from newlib can now be used and will automatically map to fio*, or to fileXio* when it's loaded.

The downside to all of this, is that there are some minor incompatibility issues between newlib's libc, and ps2sdk's libc. For instance the include file <stdio.h> in ps2sdk included a lot of things from <unistd.h> and <fcntl.h>. So existing code will have to add a few extra header files. Another more problematic incompatibility is with the file 'open' function, and 'fioOpen' and 'fileXioOpen'. Becouse the flags O_RDONLY, O_WRONLY and O_RDWR have been defined differently in newlib and ps2sdk. This has to be fixed by no longer using fioOpen and fileXioOpen, and only using 'open'. 

This pull request series consists of 5 parts, resulting in a bootable working OPL elf file:
1. ps2toolchain, for removing a lot of hacks and updating the ps2 assembly files in newlib. Upgrading to newer versions of newlib will be a lot simpler after this patch. For now it's updated from v1.10.0 to v1.14.0
2. ps2sdk, mostly for removing libc
3. gsKit, for compatibility
4. ps2sdk-ports, for compatibility
5. open-ps2-loader, for compatbility and a bugfix 

It's likely thhat we will run into some small problems for the next couple of weeks, but I'll be actively trying to fix all the problems that may be caused by these changes.