### PR TITLE
Prepare for newlib, fix bug in libtiff

### DIFF
--- a/libjpeg/src/libjpg.c
+++ b/libjpeg/src/libjpg.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdio.h>
+#include <fcntl.h>
 #include <screenshot.h>
 #include <fileXio_rpc.h>
 

--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -31,6 +31,8 @@
  */
 #include "tiffiop.h"
 #include <stdio.h>
+#include <tamtypes.h>
+#include <malloc.h>
 
 static	int gtTileContig(TIFFRGBAImage*, uint32*, uint32, uint32);
 static	int gtTileSeparate(TIFFRGBAImage*, uint32*, uint32, uint32);

--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -31,7 +31,6 @@
  */
 #include "tiffiop.h"
 #include <stdio.h>
-#include <tamtypes.h>
 #include <malloc.h>
 
 static	int gtTileContig(TIFFRGBAImage*, uint32*, uint32, uint32);
@@ -496,7 +495,7 @@ TIFFReadPS2Image(TIFF* tif,
 
     int orientation = ORIENTATION_BOTLEFT;
 
-    u32* nraster = malloc(img.width * img.height * 4);
+    u32* nraster = malloc(rwidth * rheight * 4);
 
     if (TIFFRGBAImageOK(tif, emsg) &&
         TIFFRGBAImageBegin(&img, tif, stop, emsg)) {

--- a/madplay/ee/src/Makefile
+++ b/madplay/ee/src/Makefile
@@ -18,8 +18,8 @@ EE_LIBS += -lfileXio -ldebug -lmad -lid3tag \
 
 EE_CXXFLAGS += -fno-exceptions -fno-rtti
 
-EE_CFLAGS += -DHAVE_STRNCASECMP -DHAVE_CONFIG_H -DHAVE_UNISTD_H \
-	-DHAVE_STRING_H -DHAVE_SYS_TYPES_H
+EE_CFLAGS += -DHAVE_STRNCASECMP -DHAVE_CONFIG_H -DHAVE_UNISTD_H -DHAVE_ERRNO_H \
+	-DHAVE_FCNTL_H -DHAVE_STRING_H -DHAVE_SYS_TYPES_H -DHAVE_ASSERT_H
 
 EE_INCS += -I./ -I../include -Iinclude -I$(PS2SDK)/common/include -I$(PS2SDK)/ee/include \
 	-I$(PS2SDK)/ports/include -I$(PS2DEV)/isjpcm/include

--- a/madplay/ee/src/audio_sjpcm.c
+++ b/madplay/ee/src/audio_sjpcm.c
@@ -23,8 +23,7 @@
 #  include "config.h"
 # endif
 
-# include "global.h"
-
+# include <stdio.h>
 # include <unistd.h>
 # include <errno.h>
 # include <sjpcm.h>
@@ -45,6 +44,8 @@
 #include <sifrpc.h>
 #include <sifcmd.h>
 #include <loadfile.h>
+
+# include "global.h"
 
 typedef void (*functionPointer)();
 

--- a/madplay/ee/src/madplay.c
+++ b/madplay/ee/src/madplay.c
@@ -23,8 +23,6 @@
 #  include "config.h"
 # endif
 
-# include "global.h"
-
 /* include this first to avoid conflicts with MinGW __argc et al. */
 # include "getopt.h"
 
@@ -54,6 +52,8 @@
 # include "version.h"
 # include "audio.h"
 # include "player.h"
+
+# include "global.h"
 
 # define FADE_DEFAULT	"0:05"
 

--- a/madplay/ee/src/player.c
+++ b/madplay/ee/src/player.c
@@ -23,8 +23,6 @@
 #  include "config.h"
 # endif
 
-# include "global.h"
-
 # include <stdio.h>
 # include <stdarg.h>
 # include <stdlib.h>
@@ -89,6 +87,8 @@
 
 # include "bstdfile.h"
 # include "file.h"
+
+# include "global.h"
 
 # define MPEG_BUFSZ	80000	/* 5.0 s at 128 kbps; 2 s at 320 kbps */
 # define FREQ_TOLERANCE	2	/* percent sampling frequency tolerance */


### PR DESCRIPTION
While preparing for the newlib update I've also updated/improved/fixed lots of other projects. These are the ps2sdk-ports updates:

- add include files required for newlib (and posix compatibility). These changes are compatible with the current toolchain.
- fix bug in libtiff