### PR TITLE
[Preparing for NewLib] Crash Libjepg 

### DIFF
--- a/libjpeg/src/libjpg.c
+++ b/libjpeg/src/libjpg.c
@@ -136,6 +136,7 @@ jpgData *jpgOpenRAW( u8 *data, int size, int mode )
 	if( priv == NULL )
 		return NULL;
 
+	memset( priv, 0, sizeof(jpgPrivate) );
 	jpg->priv	= priv;
 	dinfo		= &priv->dinfo;
   
@@ -309,6 +310,7 @@ jpgData *jpgCreateRAW( u8 *data, int width, int height, int bpp )
 	if( priv == NULL )
 		return NULL;
 
+	memset( priv, 0, sizeof(jpgPrivate) );
 	jpg->priv = priv;
 	cinfo = &priv->cinfo;
 
@@ -575,6 +577,7 @@ jpgData *jpgOpenFILE( FILE *in_file, int mode )
 	if( priv == NULL )
 		return NULL;
 
+	memset( priv, 0, sizeof(jpgPrivate) );
 	jpg->priv	= priv;
 	dinfo		= &priv->dinfo;
   


### PR DESCRIPTION
Solved a crash doing free(jpgPrivate) when it was not properly initialized.

With the current toolchain is not crashing so far, however with the toolchain that will use newlib is 100% reproducible.

Thanks