### PR TITLE
Fix "missing separator" error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad li
 else
 all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay romfs stlport ucl
 # ode
-@echo "GSKIT not set and gsKit not installed.\nSDL libraries were not built."
+	@echo "GSKIT not set and gsKit not installed.\nSDL libraries were not built."
 endif
 
 submodules:


### PR DESCRIPTION
Added tab indentation to fix
`Makefile:9: *** missing separator.  Stop.`
error on Linux