### PR TITLE
Move libc to newlib

### DIFF
--- a/libjpeg/src/libjpg.c
+++ b/libjpeg/src/libjpg.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <screenshot.h>
-#include <fileXio_rpc.h>
 
 #include "libjpg.h"
 #include "jpeglib.h"
@@ -198,21 +197,21 @@ jpgData *jpgOpen( char *filename, int mode )
 	int size;
 	int fd;
 
-	fd = fileXioOpen( filename, O_RDONLY, 0 );
+	fd = open( filename, O_RDONLY, 0 );
 	if( fd == -1 ) {
 		printf("jpgOpen: error opening '%s'\n", filename);
 		return NULL;
 	}
 	
-	size = fileXioLseek( fd, 0, SEEK_END );
-	fileXioLseek( fd, 0, SEEK_SET );
+	size = lseek( fd, 0, SEEK_END );
+	lseek( fd, 0, SEEK_SET );
 	
 	data = (u8*)malloc(size);
 	if( data == NULL )
 		return NULL;
 	
-	fileXioRead( fd, data, size );
-	fileXioClose(fd);
+	read( fd, data, size );
+	close(fd);
 
 	jpg = jpgOpenRAW( data, size, mode );
 	if( jpg == NULL )
@@ -406,7 +405,7 @@ int jpgScreenshot( const char* pFilename,unsigned int VramAdress, unsigned int W
 	u8 *data;
 	int ret;
 
-	file_handle = fileXioOpen( pFilename, O_CREAT | O_WRONLY, 0 );
+	file_handle = open( pFilename, O_CREAT | O_WRONLY, 0 );
 
 	// make sure we could open the file for output
 	if( file_handle < 0 )
@@ -481,10 +480,10 @@ int jpgScreenshot( const char* pFilename,unsigned int VramAdress, unsigned int W
 	jpg = jpgCreateRAW(out_buffer, Width, Height, 24);
 	ret = jpgCompressImageRAW(jpg, &data);
 	
-	fileXioWrite( file_handle, data, ret );
+	write( file_handle, data, ret );
 	jpgClose(jpg);
 
-	fileXioClose( file_handle );
+	close( file_handle );
 	free(out_buffer);
 
 	return 0;

--- a/libmikmod/mmio/mmio_ps2.c
+++ b/libmikmod/mmio/mmio_ps2.c
@@ -67,6 +67,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 
 #include "mikmod_internals.h"
 

--- a/libtiff/tif_getimage.c
+++ b/libtiff/tif_getimage.c
@@ -31,6 +31,7 @@
  */
 #include "tiffiop.h"
 #include <stdio.h>
+#include <tamtypes.h>
 #include <malloc.h>
 
 static	int gtTileContig(TIFFRGBAImage*, uint32*, uint32, uint32);

--- a/libtiff/tif_ps2.c
+++ b/libtiff/tif_ps2.c
@@ -54,25 +54,25 @@
 static tsize_t
 _tiffReadProc(thandle_t fd, tdata_t buf, tsize_t size)
 {
-	return ((tsize_t) fioRead((int) fd, buf, (size_t) size));
+	return ((tsize_t) read((int) fd, buf, (size_t) size));
 }
 
 static tsize_t
 _tiffWriteProc(thandle_t fd, tdata_t buf, tsize_t size)
 {
-	return ((tsize_t) fioWrite((int) fd, buf, (size_t) size));
+	return ((tsize_t) write((int) fd, buf, (size_t) size));
 }
 
 static toff_t
 _tiffSeekProc(thandle_t fd, toff_t off, int whence)
 {
-	return ((toff_t) fioLseek((int) fd, (off_t) off, whence));
+	return ((toff_t) lseek((int) fd, (off_t) off, whence));
 }
 
 static int
 _tiffCloseProc(thandle_t fd)
 {
-	return (fioClose((int) fd));
+	return (close((int) fd));
 }
 
 
@@ -127,7 +127,7 @@ TIFFOpen(const char* name, const char* mode)
 	int fd;
         TIFF* tif;
 
-	fd = fioOpen(name, O_RDONLY);
+	fd = open(name, O_RDONLY);
 
 	if (fd < 0) {
 		TIFFError(module, "%s: Cannot open", name);
@@ -136,7 +136,7 @@ TIFFOpen(const char* name, const char* mode)
 
 	tif = TIFFFdOpen((int)fd, name, mode);
 	if(!tif)
-		fioClose(fd);
+		close(fd);
 	return tif;
 }
 

--- a/madplay/ee/include/directory.h
+++ b/madplay/ee/include/directory.h
@@ -12,7 +12,7 @@ struct object
 
 struct folder
 {
-	int iDir;
+	DIR *pDir;
 	int fIndex;
 	int fMax;
 	char full[512];

--- a/madplay/ee/src/bstdfile.c
+++ b/madplay/ee/src/bstdfile.c
@@ -49,29 +49,15 @@ the hard drive*/
 /****************************************************************************
  * Includes.																*
  ****************************************************************************/
-#include "tamtypes.h"
 #include <stdio.h>
-#include <sifrpc.h>
-#include <sifcmd.h>
-#include "sys/stat.h"
-#include "sys/fcntl.h"
-#include <sys/types.h>
-#include "kernel.h"
-#include "string.h"
-#include "libhdd.h"
-#include "fileio.h"
-#include "iopcontrol.h"
-#include "stdarg.h"
-#include "malloc.h"
-#include "libmc.h"
-#include "iopheap.h"
-#include "sys/ioctl.h"
-#include "fileXio_rpc.h"
-#include "errno.h"
+#include <tamtypes.h>
+#include <malloc.h>
+#include <kernel.h>
+#include <string.h>
+#include <errno.h>
+
 #include "rmalloc.h"
 #include "file.h"
-
-
 #include "bstdfile.h"
 
 /****************************************************************************
@@ -196,7 +182,6 @@ int BstdFileDestroy(bstdfile_t *BstdFile)
 		errno=EBADF;
 		return(1);
 	}
-	//fileXioClose(BstdFile->fp);
 	CloseFile(BstdFile->fp, mediaMode);
 	if (memoryFile)
 	{

--- a/madplay/ee/src/directory.c
+++ b/madplay/ee/src/directory.c
@@ -29,7 +29,6 @@
 #include "errno.h"
 #include "string.h"
 #include "libhdd.h"
-#include "fileio.h"
 #include "debug.h"
 #include "sjpcm.h"
 #include "sbv_patches.h"

--- a/madplay/ee/src/file.c
+++ b/madplay/ee/src/file.c
@@ -28,7 +28,6 @@
 #include "errno.h"
 #include "string.h"
 #include "libhdd.h"
-#include "fileio.h"
 #include "debug.h"
 #include "sjpcm.h"
 #include "sbv_patches.h"

--- a/madplay/ee/src/file.c
+++ b/madplay/ee/src/file.c
@@ -25,7 +25,6 @@
 #include "stdarg.h"
 #include "iopheap.h"
 #include "sys/ioctl.h"
-#include "fileXio_rpc.h"
 #include "errno.h"
 #include "string.h"
 #include "libhdd.h"
@@ -85,68 +84,11 @@ setPathInfo(int argc, char **argv)
 
 
 /****************************************************************************
- * Mounts a hard disk partition.											*
- ****************************************************************************/
-int OpenPartition(char *part)
-{
-	int fd;
-	fd = fileXioMount("pfs0:", part, FIO_MT_RDWR);
-	if (fd < 0) { printf("Cannot mount partition\n"); return -1; }
-	return 0;
-}
-
-/****************************************************************************
- * Unmounts a hard disk partition.											*
- ****************************************************************************/
-int ClosePartition()
-{
-	fileXioUmount("pfs0:");
-	return 0;
-}
-
-/****************************************************************************
  * Universal file opening function.  Returns the handle to the file.		*
  ****************************************************************************/
 int OpenFile(char *filename, int mode, int media)
 {
-	int fd = 0;
-	switch (media)
-	{
-	case 0:  //hdd
-		{
-			fd = fileXioOpen(filename, mode, 0);
-			break;
-		}
-	case 1:  //cdfs
-		{
-//			CDVD_FlushCache();
-// fixme: update to ps2sdk
-			fd = fioOpen(filename, mode);
-			break;
-		}
-	case 2:
-		{
-			//fd = fioOpen(filename, mode);
-			fd = fileXioOpen(filename, mode, 0);
-			break;
-		}
-	case 3:
-		{
-			fd = fileXioOpen(filename, mode, 0);
-			break;	
-		}
-	case 4:
-		{
-			fd = fioOpen(filename, mode);
-			break;	
-		}
-	case 5:
-		{
-			fd = fileXioOpen(filename, mode, 0);
-			break;	
-		}
-	}
-	return fd;
+	return open(filename, mode, 0);
 }
 
 /****************************************************************************
@@ -154,43 +96,7 @@ int OpenFile(char *filename, int mode, int media)
  ****************************************************************************/
 void CloseFile(int handle, int media)
 {
-	switch (media)
-	{
-	case 0:  //hdd
-		{
-			fileXioClose(handle);
-			break;
-		}
-	case 1:  //cdfs
-		{
-			fioClose(handle);
-			//CDVD_Stop();
-//			cdStop();
-			break;
-		}
-	case 2: //mc0
-		{
-			//fioClose(handle);
-			fileXioClose(handle);
-			break;
-		}	
-	case 3:
-		{
-			//fioClose(handle);
-			fileXioClose(handle);
-			break;
-		}		
-	case 4:
-		{
-			fioClose(handle);
-			break;
-		}	
-	case 5:
-		{
-			fileXioClose(handle);
-			break;
-		}			
-	}
+	close(handle);
 }
 
 
@@ -199,44 +105,7 @@ void CloseFile(int handle, int media)
  ****************************************************************************/
 int ReadFile(int handle, unsigned char *buffer, int size, int media)
 {
-	int sr =0;
-//	printf ("ReadFile(%d, %p, %d, %d)\n", handle, buffer, size, media);
-	switch (media)
-	{
-	case 0:
-		{
-			sr = fileXioRead(handle, buffer, size);
-			break;
-		}
-	case 1:
-		{
-			sr = fioRead(handle, buffer, size);
-			break;
-		}
-	case 2:
-		{
-			//sr = fioRead(handle, buffer, size);
-			sr = fileXioRead(handle, buffer, size);
-			break;
-		}
-	case 3:
-		{
-			//sr = fioRead(handle, buffer, size);
-			sr = fileXioRead(handle, buffer, size);
-			break;
-		}
-	case 4:
-		{
-			sr = fioRead(handle, buffer, size);
-			break;
-		}
-	case 5:
-		{
-			sr = fileXioRead(handle, buffer, size);
-			break;
-		}
-	}
-	return sr;
+	return read(handle, buffer, size);
 }
 
 /****************************************************************************
@@ -244,43 +113,7 @@ int ReadFile(int handle, unsigned char *buffer, int size, int media)
  ****************************************************************************/
 int SeekFile(int handle, int pos, int rel, int media)
 {
-	int sr=0;
-	switch (media)
-	{
-	case 0:
-		{
-			sr = fileXioLseek(handle, pos, rel);
-			break;
-		}
-	case 1:
-		{
-			sr = fioLseek(handle, pos, rel);
-			break;
-		}
-	case 2:
-		{
-			//sr = fioLseek(handle, pos, rel);
-			sr = fileXioLseek(handle, pos, rel);
-			break;
-		}
-	case 3:
-		{
-			//sr = fioLseek(handle, pos, rel);
-			sr = fileXioLseek(handle, pos, rel);
-			break;
-		}
-	case 4:
-		{
-			sr = fioLseek(handle, pos, rel);
-			break;
-		}
-	case 5:
-		{
-			sr = fileXioLseek(handle, pos, rel);
-			break;
-		}
-	}
-	return sr;
+	return lseek(handle, pos, rel);;
 }
 	
 
@@ -290,8 +123,7 @@ int SeekFile(int handle, int pos, int rel, int media)
  ****************************************************************************/
 void closeShop(int handle)
 {
-	fileXioClose(handle);
-	fileXioUmount("pfs0:");
+	close(handle);
 }
 
 //from now elf loading functions
@@ -358,24 +190,24 @@ int RunElf(char *name)
 	fd=-1;
 	if(name[0]=='m' && name[1]=='c') // if mc, test mc0 and mc1
 	{
-		if((fd = fioOpen(name,1)) < 0) 
+		if((fd = open(name,1)) < 0) 
 		{
 			name[2]='1';
 		}
 	}
 	if(fd < 0)
-		if((fd = fioOpen(name,1)) < 0) 
+		if((fd = open(name,1)) < 0) 
 		{
 			return -1;
 		}
-		size = fioLseek(fd, 0, SEEK_END);
+		size = lseek(fd, 0, SEEK_END);
 		if(!size) {
-			fioClose(fd);
+			close(fd);
 			return -2;
 		}
 
-		fioLseek(fd, 0, 0);
-		fioRead(fd, eh, sizeof(elf_header_t)); // read the elf header
+		lseek(fd, 0, 0);
+		read(fd, eh, sizeof(elf_header_t)); // read the elf header
 
 		// crazy code for crazy man :P
 		boot_elf=(u8 *)0x1800000-size-256; 
@@ -383,8 +215,8 @@ int RunElf(char *name)
 		boot_elf=(u8 *) (((unsigned)boot_elf) &0xfffffff0);
 
 		// read rest file elf
-		fioRead(fd, boot_elf+sizeof(elf_header_t), size-sizeof(elf_header_t));
-		fioClose(fd);
+		read(fd, boot_elf+sizeof(elf_header_t), size-sizeof(elf_header_t));
+		close(fd);
 
 		// mrbrown machine gun ;)
 		eph = (elf_pheader_t *)(boot_elf + eh->phoff);

--- a/romfs/include/romfs.h
+++ b/romfs/include/romfs.h
@@ -19,6 +19,8 @@
 extern "C" {
 #endif
 
+#define _NFILE 20
+
 extern unsigned char romdisk_start[];
 
 int romdisk_mount(const void *img);

--- a/romfs/src/romfs_io.c
+++ b/romfs/src/romfs_io.c
@@ -13,8 +13,8 @@
 
 
 #include <stdio.h>
+#include <fcntl.h>
 #include <string.h>
-#include <io_common.h>
 #include <errno.h>
 
 // handle romdisk 

--- a/romfs/src/romfs_io.c
+++ b/romfs/src/romfs_io.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <io_common.h>
+#include <errno.h>
 
 // handle romdisk 
 #include "romfs.h"
@@ -41,7 +42,7 @@ void rioInit()
 		// except stdout, stdin and stderr (even if not relevent here)
 		for(i=3;i<_NFILE;i++)
 		{
-			__riob[i].fd = -1;
+			__riob[i]._file = -1;
 			__sz[i] = 0;
 			__offset[i] = 0;
 			__dataptr[i] = 0;
@@ -71,7 +72,7 @@ int rioOpen(char* path, int mode)
 	fd = -1;
 	for(i=3;i<_NFILE;i++)
 	{
-		if(__riob[i].fd == -1)
+		if(__riob[i]._file == -1)
 		{
 			fd = i;
 			break;
@@ -86,7 +87,7 @@ int rioOpen(char* path, int mode)
 	if (romdisk_find(path, (void **)&(__dataptr[fd]), &(__sz[fd])) == 0)
 	{
 		// set the new fd
-		 __riob[i].fd = fd;
+		 __riob[i]._file = fd;
 		return fd;
 	}
 	else
@@ -120,7 +121,7 @@ int 	rioWrite(int fd, const void *buff, size_t buff_size)
 
 int 	rioClose(int fd)
 {	
-	__riob[fd].fd = -1;
+	__riob[fd]._file = -1;
 	__sz[fd] = 0;
 	__offset[fd] = 0;
 	__dataptr[fd] = 0;
@@ -228,13 +229,13 @@ FILE	*ropen(const char * fname, const char * mode)
 
 int    	rclose(FILE * stream)
 {
-	rioClose (stream->fd);
+	rioClose (stream->_file);
 	return 0;
 }
 
 size_t  rread(void *buf, size_t r, size_t n, FILE *stream)
 {
-	return (size_t)((rioRead(stream->fd, buf, (int)r * (int)n)) / r);
+	return (size_t)((rioRead(stream->_file, buf, (int)r * (int)n)) / r);
 }
 size_t 	rwrite(const void *buf, size_t r, size_t n, FILE *stream)
 {
@@ -243,24 +244,24 @@ size_t 	rwrite(const void *buf, size_t r, size_t n, FILE *stream)
 }
 int    	rseek(FILE *stream, long offset, int origin)
 {
-	return rioLseek( stream->fd, offset, origin);
+	return rioLseek( stream->_file, offset, origin);
 }
 long 	rtell(FILE *stream)
 {
-	return (long)__offset[stream->fd];
+	return (long)__offset[stream->_file];
 }
 int 	rsize(FILE *stream)
 {
-	return rioSize(stream->fd);
+	return rioSize(stream->_file);
 }
 int     rgetc(FILE *stream)
 {
-	return rioGetc(stream->fd);
+	return rioGetc(stream->_file);
 }
 char    *rgets(char *buf, int n, FILE *stream)
 {
 	
-	if (rioGets(stream->fd, buf, n)>0)
+	if (rioGets(stream->_file, buf, n)>0)
 		return (buf);
 	else
 		return NULL;

--- a/stlport/src/Makefile
+++ b/stlport/src/Makefile
@@ -37,7 +37,7 @@ include common_macros.mak
 WARNING_FLAGS= -Wall -W -Wno-sign-compare -Wno-unused -Wno-uninitialized
 #-ftemplate-depth-32 -frtti
 
-CXXFLAGS_COMMON = -I${STLPORT_DIR} ${WARNING_FLAGS} -I${PS2SDK}/common/include -I${PS2SDK}/ee/include -I${PS2DEV}/ee/include/c++/3.2.2 -I${PS2DEV}/ee/include/c++/3.2.2/ee
+CXXFLAGS_COMMON = -I${STLPORT_DIR} ${WARNING_FLAGS} -I${PS2SDK}/common/include -I${PS2SDK}/ee/include
 
 CXXFLAGS_RELEASE_static = $(CXXFLAGS_COMMON) -O2
 

--- a/stlport/src/fstream.cpp
+++ b/stlport/src/fstream.cpp
@@ -91,7 +91,7 @@ extern "C" {
 #  if defined(__ISCPP__)
 #   include <c_locale_is/filestat.h>
 #  endif
-#  if defined(__BEOS__) && defined(__INTEL__)
+#if  defined(_EE) || (defined(__BEOS__) && defined(__INTEL__))
 #   include <fcntl.h>
 #   include <sys/stat.h>         // For _fstat
 #   define _S_IREAD S_IREAD
@@ -199,12 +199,12 @@ ios_base::openmode flag_to_openmode(int mode)
 
 bool __is_regular_file(_STLP_fd fd) {
 
-#if defined (_STLP_UNIX)
+#if defined (_STLP_UNIX) || defined(_EE)
 
   struct stat buf;
   return fstat(fd, &buf) == 0 && S_ISREG(buf.st_mode);
 
-#elif defined(__MRC__) || defined(__SC__) || defined(_EE)		//*TY 02/25/2000 - added support for MPW compilers
+#elif defined(__MRC__) || defined(__SC__)		//*TY 02/25/2000 - added support for MPW compilers
 
   #pragma unused(fd)
   return true;  // each file is a regular file under mac os, isn't it? (we don't have fstat())
@@ -229,13 +229,13 @@ bool __is_regular_file(_STLP_fd fd) {
 streamoff __file_size(_STLP_fd fd) {
  streamoff ret = 0;
 
-#if defined (_STLP_UNIX)
+#if defined (_STLP_UNIX) || defined(_EE)
 
   struct stat buf;
   if(fstat(fd, &buf) == 0 && S_ISREG(buf.st_mode))
     ret = buf.st_size > 0 ? buf.st_size : 0;
 
-#elif defined(__MRC__) || defined(__SC__) || defined(_EE)		//*TY 02/25/2000 - added support for MPW compilers
+#elif defined(__MRC__) || defined(__SC__)		//*TY 02/25/2000 - added support for MPW compilers
 
   #pragma unused(fd)
 
@@ -664,7 +664,7 @@ bool _Filebuf_base::_M_open(const char* name, ios_base::openmode openmode)
   // bits that are set in the umask from the permissions flag.
 # ifdef _STLP_USE_WIN32_IO
   return this->_M_open(name, openmode, FILE_ATTRIBUTE_NORMAL);
-# elif defined(__MRC__) || defined(__SC__) || defined(_EE)		//*TY 02/26/2000 - added support for MPW compilers
+# elif defined(__MRC__) || defined(__SC__)		//*TY 02/26/2000 - added support for MPW compilers
   return this->_M_open(name, openmode, 0);
 # else
   return this->_M_open(name, openmode, S_IRUSR | S_IWUSR | S_IRGRP | 
@@ -681,7 +681,7 @@ bool _Filebuf_base::_M_open(int file_no, ios_base::openmode init_mode) {
   if (_M_is_open || file_no < 0)
     return false;
 
-# if defined (_STLP_UNIX)
+# if defined (_STLP_UNIX) || defined(_EE)
   (void)init_mode;    // dwa 4/27/00 - suppress unused parameter warning
   int mode ;
   mode = fcntl(file_no, F_GETFL);
@@ -694,20 +694,6 @@ bool _Filebuf_base::_M_open(int file_no, ios_base::openmode init_mode) {
 # elif defined(__MRC__) || defined(__SC__)		//*TY 02/26/2000 - added support for MPW compilers
   (void)init_mode;    // dwa 4/27/00 - suppress unused parameter warning
   switch( _iob[file_no]._flag & (_IOREAD|_IOWRT|_IORW) )
-  {
-  case _IOREAD:
-    _M_openmode = ios_base::in; break;
-  case _IOWRT:
-    _M_openmode = ios_base::out; break;
-  case _IORW:
-    _M_openmode = ios_base::in | ios_base::out; break;
-  default:
-  	return false;
-  }
-
-# elif defined(_EE)
-  (void)init_mode;    // dwa 4/27/00 - suppress unused parameter warning
-  switch( __iob[file_no].flag & (_IOREAD|_IOWRT|_IORW) )
   {
   case _IOREAD:
     _M_openmode = ios_base::in; break;

--- a/stlport/stlport/stl/_stdio_file.h
+++ b/stlport/stlport/stl/_stdio_file.h
@@ -722,19 +722,23 @@ inline void _FILE_I_set(FILE *__f, char* __begin, char* __next, char* __end) {
 
 #elif defined (_EE)
 
-inline int _FILE_fd(const FILE * f) { return f->fd; }
-inline char * _FILE_I_begin(const FILE * f) { return (char *) &(f->putback); }
-inline char * _FILE_I_next(const FILE * f) { return (char *) &(f->putback); }
-inline char * _FILE_I_end(const FILE * f) { return (char *) &(f->putback); }
+inline int _FILE_fd(const FILE * f) { return f->_file; }
+inline char * _FILE_I_begin(const FILE * f) { return (char *) (f->_bf._base); }
+inline char * _FILE_I_next(const FILE * f) { return (char *) (f->_p); }
+inline char * _FILE_I_end(const FILE * f) { return (char *) (f->_bf._base + f->_bf._size); }
 
-inline ptrdiff_t _FILE_I_avail(const FILE * f) { return 0; }
+inline ptrdiff_t _FILE_I_avail(const FILE * f) { return f->_bf._size; }
 
-inline char & _FILE_I_preincr(FILE * f) { return (char) f->putback; }
-inline char & _FILE_I_postincr(FILE * f) { return (char) f->putback; }
-inline char & _FILE_I_predecr(FILE * f) { return (char) f->putback; }
-inline char & _FILE_I_postdecr(FILE * f) { return (char) f->putback; }
-inline void _FILE_I_bump(FILE * f, int n) { }
-inline void _FILE_I_set(FILE * f, char * begin, char * next, char * end) { }
+inline char & _FILE_I_preincr(FILE * f) { --f->_bf._size; return *(char*) (++f->_p); }
+inline char & _FILE_I_postincr(FILE * f) { --f->_bf._size; return *(char*) (f->_p++);}
+inline char & _FILE_I_predecr(FILE * f) { ++f->_bf._size; return *(char*) (++f->_p); }
+inline char & _FILE_I_postdecr(FILE * f) { ++f->_bf._size; return *(char*) (f->_p++);}
+inline void _FILE_I_bump(FILE * f, int n) { f->_p += n; f->_bf._size -= n; }
+inline void _FILE_I_set(FILE * f, char * begin, char * next, char * end) { 
+  f->_bf._base = (unsigned char*)begin;
+  f->_p  = (unsigned char*)next;
+  f->_bf._size  = end - next;
+}
 
 # define _STLP_FILE_I_O_IDENTICAL
 


### PR DESCRIPTION
These PR series move libc from ps2sdk to newlib:

**1**: File and directory functions (both fio* and fileXio*) are now handled by newlib, tranparently. With the following functions supported:
-- close/open
-- read/write
-- lseek
-- ioctl
-- unlink (remove)
-- link (rename)
-- mkdir/rmdir
-- stat
-- opendir/closedir
-- readdir
-- rewinddir

Existing code must be modified to use these standard posix function names instead of calling fio* fileXio functions directly, becouse of an incompatibility between newlib and the ps2 file handing. For this reason existing code will provide an error when including ps2 headers that should not be used:

> #error "Using fio/fileXio functions directly in the newlib port will lead to problems."
> #error "Use posix function calls instead."

For some applications however, using the fio*/fileXio* functions directly may still be needed (for instance when mounting partitions). By defining 'NEWLIB_PORT_AWARE' before including these headers this is still possible.
As far as I know the only incompatibility it with opening a file. The flags, like O_RDONLY, are incompatible and must be changed to **FIO**_O_RDONLY.

**2**: time function is implemented, returning the UTC time. Using the stat function the times from files can also be returned in UTC format.

**3**: nanosleep is implemented. It sleeps using SetAlarm. Then busy waits the last nanoseconds, resulting in both a lot of free cpu time, and a very accurate sleep time.

**4**: The linkfile has been moved to the binutils port, and crt0.s has been moved to newlib port.

**5**: The newlib port is upgraded from 1.10 to 1.14. This adds  (amongs other things) wchar support, needed by some applications like uLE. Upgrading to newer versions resulted in a lot of compiler issues. Perhaps newlib can be upgraded to 3.x when the compiler gets updated.

The end result is that porting new applications to the ps2 will become a lot more easy. Or sometimes they will just run.

Special thanks to @fjtrujy, the creator of the PS2 RetroArch port, for making this possible.

---

This PR series consists of ps2toolchain, ps2sdk, ps2sdk-ports and gsKit to get a working newlib toolchain. This is the ps2sdk-ports PR. These are prepared by @fjtrujy . They can also serve as an example to what needs to be changed for the newlib port.