### PR TITLE
Automate generation of Docker Image

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        apk add gcc musl-dev git
+        apk add build-base git
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -22,5 +22,4 @@ jobs:
 
     - name: Compile project
       run: |
-        ls -la
         make

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: fjtrujy/ps2dev:gskit-latest
+    container: ${{ github.repository_owner }}/gskit:latest
     steps:
     - name: Install dependencies
       run: |

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: fjtrujy/ps2dev:gskit-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        apk add gcc musl-dev git
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0
+
+    - name: Compile project
+      run: |
+        ls -la
+        make

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,5 +18,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ github.repository_owner }}/ps2dev
-        tags: ports-latest
+        repository: ${{ env.GITHUB_REPOSITORY }}
+        tags: latest
+        build_args: BASE_DOCKER_IMAGE=${{ github.repository_owner }}/gskit:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,22 @@
+name: CI-Docker
+
+on:
+  push:
+    branches:
+      - master
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ${{ github.repository_owner }}/ps2dev
+        tags: ports-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM fjtrujy/ps2dev:gskit-latest
+
+COPY . /src/ps2sdk-ports
+
+RUN \
+  apk add --no-cache --virtual .build-deps gcc musl-dev git && \
+  cd /src/ps2sdk-ports && \
+  make && \
+  apk del .build-deps && \
+  rm -rf \
+    /src/* \
+    /tmp/*
+
+WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM fjtrujy/ps2dev:gskit-latest
+ARG BASE_DOCKER_IMAGE
+
+FROM $BASE_DOCKER_IMAGE
 
 COPY . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM fjtrujy/ps2dev:gskit-latest
 
-COPY . /src/ps2sdk-ports
+COPY . /src
 
-RUN \
-  apk add --no-cache --virtual .build-deps gcc musl-dev git && \
-  cd /src/ps2sdk-ports && \
-  make && \
-  apk del .build-deps && \
-  rm -rf \
-    /src/* \
-    /tmp/*
+RUN apk add build-base git
+RUN cd /src && make
 
-WORKDIR /src
+FROM alpine:latest  
+
+ENV PS2DEV /usr/local/ps2dev
+ENV PS2SDK $PS2DEV/ps2sdk
+ENV PATH   $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/bin:${PS2SDK}/bin
+ENV GSKIT=$PS2DEV/gsKit
+
+COPY --from=0 ${PS2DEV} ${PS2DEV}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PS2SDK-PORTS
 
+![CI](https://github.com/ps2dev/ps2sdk-ports/workflows/CI/badge.svg)
+![CI-Docker](https://github.com/ps2dev/ps2sdk-ports/workflows/CI-Docker/badge.svg)
+
 ## What is it ?
 This git repository contains various number of ports working with the current `ps2sdk`. It is not intended to be a releasable package.
 


### PR DESCRIPTION
## Descriptions
This PR integrates CI/CD in the repo. The main purpose of this CI/CD are:

- Now in advance, if a PR pending to be merged to `Master` is compiling.
- Generate a docker image `ps2dev/ps2sdk-ports:latest`, for being used latest by https://github.com/ps2dev/gskit as based image.

In total there is a group of 4 PRs to implement the flow. If we want to have the CI/CD `green` since the beginning we need to merge them **in order and after the previous one finish the workflows**.

The proper order is:

1. https://github.com/ps2dev/ps2toolchain/pull/67
2. https://github.com/ps2dev/ps2sdk/pull/118
3. https://github.com/ps2dev/gsKit/pull/36
4. https://github.com/ps2dev/ps2sdk-ports/pull/50

Everything has been done, thanks to:
- @ooPo for giving me the grants in the `ps2dev` group in `GitHub`.
- @AKuHAK for giving me the grants to the `ps2dev` group in `Docker Hub`
- @rickgaiser for being involved in the whole process since the first minute.


