### PR TITLE
Repo Improvements

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
   repository_dispatch:
     types: [run_build]
 
@@ -13,14 +15,37 @@ jobs:
   
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-    - uses: docker/build-push-action@v1
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ env.GITHUB_REPOSITORY }}
-        tags: latest
-        build_args: BASE_DOCKER_IMAGE=${{ github.repository_owner }}/gskit:latest
+    
+    - uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: ${{ github.repository }}:${{ env.DOCKER_TAG }}
+        build-args: |
+          BASE_DOCKER_IMAGE=${{ github.repository_owner }}/gskit:${{ env.DOCKER_TAG }}
     
     - name: Send Compile action
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        submodules: true
         fetch-depth: 0
 
     - name: Extract DOCKER_TAG using tag name

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/glennrp/libpng
 [submodule "freetype2/src"]
 	path = freetype2/src
-	url = https://git.savannah.gnu.org/git/freetype/freetype2
+	url = https://github.com/freetype/freetype2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM $BASE_DOCKER_IMAGE
 COPY . /src
 
 RUN apk add build-base git
-RUN cd /src && make
+RUN cd /src && make libraries
 
 FROM alpine:latest  
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer sdlttf stlport ucl
 
 ifneq ("$(wildcard $(GSKIT)/include/gsKit.h)","")
-all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf stlport ucl
+all: submodules libraries
+libraries: aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf stlport ucl
 # ode
 else
-all: submodules aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay romfs stlport ucl
+all: submodules libraries
+libraries: aalib expat freetype2 libconfig libid3tag zlib libjpeg libmad libmikmod libpng libtap libtiff lua madplay romfs stlport ucl
 # ode
 	@echo "GSKIT not set and gsKit not installed.\nSDL libraries were not built."
 endif
@@ -23,7 +25,6 @@ expat:
 	$(MAKE) -C $@ clean
 
 freetype2:
-	git submodule update --init freetype2	
 	cd $@; ./SetupPS2.sh
 
 libconfig:
@@ -33,7 +34,6 @@ libconfig:
 
 ZLIB_FLAGS = --static --prefix=$(PS2SDK)/ports
 zlib:
-	git submodule update --init zlib
 	cd $@/src && CHOST=ee CFLAGS="-O2 -G0" ./configure $(ZLIB_FLAGS)
 	$(MAKE) -C $@/src clean
 	$(MAKE) -C $@/src all
@@ -63,14 +63,12 @@ LIBPNG_FLAGS = --host=mips64el --enable-static=true --enable-shared=false CC=ee-
 LIBPNG_FLAGS += CFLAGS="-O2 -G0" CPPFLAGS="-I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(PS2SDK)/ports/include" 
 LIBPNG_FLAGS += LDFLAGS="-L$(PS2SDK)/ee/lib -L$(PS2SDK)/ports/lib" --prefix=$(PS2SDK)/ports
 libpng: zlib
-	git submodule update --init libpng
 	cd $@/src && ./configure $(LIBPNG_FLAGS)
 	$(MAKE) -C $@/src clean
 	$(MAKE) -C $@/src all
 	$(MAKE) -C $@/src install
 
 libtap:
-	git submodule update --init libtap
 	$(MAKE) -C $@ -f Makefile.PS2 all
 	$(MAKE) -C $@ -f Makefile.PS2 install
 	$(MAKE) -C $@ -f Makefile.PS2 clean


### PR DESCRIPTION
## Description 

This PR is making some improvements.

1. Now automatically create a specific docker tag, if a git tag is created in the repo if the tag starts by v.
So for instance, if we create a tag in the repo as v1.2.0 this will create a new docker layer image named ps2dev/ps2sdk-ports:v1.2.0

If not, as usual, every single change will create a tag named ps2dev/ps2sdk-ports:latest

2. `freetype2` repo reference is down ( https://git.savannah.gnu.org/git/freetype/freetype2 ), now we have migrated to the official github repo: https://github.com/freetype/freetype2

3. Additionally due to an issue in the checkout step ( https://github.com/actions/checkout/issues/363 ) we have changed `makefile` to skip the download of submodules during `make`

Thanks.

