### PR TITLE
Fix random MinGW crashes

### DIFF
--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -19,9 +19,7 @@ function build {
     mkdir -p build
     cd build
     cmake $CMAKE_OPTIONS $2 "${XTRA_OPTS[@]}" .. || { exit 1; }
-    ${MAKECMD} --quiet -j $PROC_NR clean || { exit 1; }
-    ${MAKECMD} --quiet -j $PROC_NR all || { exit 1; }
-    ${MAKECMD} --quiet -j $PROC_NR install || { exit 1; }
+    ${MAKECMD} --quiet -j $PROC_NR clean all install || { exit 1; }
     cd ../..
 }
 


### PR DESCRIPTION
MinGW can crash if -j is greater than 2 and multiple instances of make are run. This can be fixed by using -j 1 or by removing multiple make calls.