### PR TITLE
Update freetype repo reference

### DIFF
--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -40,7 +40,7 @@ cd build
 ##
 git clone --depth 1 -b v1.2.11 https://github.com/madler/zlib || { exit 1; }
 git clone --depth 1 -b v1.6.37 https://github.com/glennrp/libpng || { exit 1; }
-git clone --depth 1 -b VER-2-10-4 https://gitlab.freedesktop.org/freetype/freetype || { exit 1; }
+git clone --depth 1 -b VER-2-10-4 https://github.com/freetype/freetype.git || { exit 1; }
 git clone --depth 1 -b 0.2.5 https://github.com/yaml/libyaml || { exit 1; }
 
 ##


### PR DESCRIPTION
Sometimes the connection between `gitlab` and `github` fails, let's change and use the official mirror of `github`