### PR TITLE
Add `gskit` as dependency

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ps2dev/gskit:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Install dependencies
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
   
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Extract DOCKER_TAG using tag name
       if: startsWith(github.ref, 'refs/tags/')
@@ -29,22 +29,16 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/') != true
       run: |
         echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
       
     - name: Login to DockerHub
       if: env.DOCKER_USERNAME != null
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Login to Github Container Registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -73,11 +67,20 @@ jobs:
         export DISPATCH_ACTION="$(echo run_build)"
         echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
 
-    - name: Repository Dispatch
-      uses: peter-evans/repository-dispatch@v1
+    - name: Repository Dispatch to ps2dev
+      uses: peter-evans/repository-dispatch@v2
       if: env.DISPATCH_TOKEN != null
       with:
         repository: ${{ github.repository_owner }}/ps2dev
+        token: ${{ secrets.DISPATCH_TOKEN }}
+        event-type: ${{ env.NEW_DISPATCH_ACTION }}
+        client-payload: '{"ref": "${{ github.ref }}"}'
+
+    - name: Repository Dispatch to gsKit
+      uses: peter-evans/repository-dispatch@v2
+      if: env.DISPATCH_TOKEN != null
+      with:
+        repository: ${{ github.repository_owner }}/gsKit
         token: ${{ secrets.DISPATCH_TOKEN }}
         event-type: ${{ env.NEW_DISPATCH_ACTION }}
         client-payload: '{"ref": "${{ github.ref }}"}'

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,14 @@
 .PHONY: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer sdlttf unzip
 
-ifneq ("$(wildcard $(GSKIT)/include/gsKit.h)","")
 all: libraries
 libraries: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf unzip
-# ode
-else
-all: libraries
-libraries: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay romfs unzip
-# ode
-	@echo "GSKIT not set and gsKit not installed.\nSDL libraries were not built."
-endif
 
 aalib:
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean
 
-ps2_drivers:
-	rm -rf $@
-	git clone --depth 1 -b 1.3.1 https://github.com/fjtrujy/ps2_drivers
-	$(MAKE) -C $@ all
-	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
-
-cmakelibs: ps2_drivers
+cmakelibs: ps2_drivers libtiff
 	./build-cmakelibs.sh
 
 expat:
@@ -80,6 +65,13 @@ madplay: cmakelibs libid3tag libmad
 # Broken
 ode:
 	$(MAKE) -C $@
+	$(MAKE) -C $@ install
+	$(MAKE) -C $@ clean
+
+ps2_drivers:
+	rm -rf $@
+	git clone --depth 1 -b 1.3.1 https://github.com/fjtrujy/ps2_drivers
+	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean
 

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -75,6 +75,9 @@ git clone https://github.com/Konstanty/libmodplug.git || { exit 1; }
 git clone https://git.code.sf.net/p/mikmod/mikmod mikmod-mikmod || { exit 1; } 
 (cd mikmod-mikmod && git checkout 187e55986a5888a8ead767a38fc29a8fc0ec5bbe && cd -) || { exit 1; }
 
+# SDL requires to have gsKit
+git clone --depth 1 -b v1.3.2 https://github.com/ps2dev/gsKit || { exit 1; } 
+
 git clone --depth 1 -b release-2.24.1 https://github.com/libsdl-org/SDL.git || { exit 1; }
 git clone --depth 1 -b release-2.6.2 https://github.com/libsdl-org/SDL_mixer.git || { exit 1; }
 git clone --depth 1 -b release-2.6.2 https://github.com/libsdl-org/SDL_image.git || { exit 1; }
@@ -101,6 +104,9 @@ build opusfile -DOP_DISABLE_HTTP=ON -DOP_DISABLE_DOCS=ON -DOP_DISABLE_EXAMPLES=O
 build libmodplug
 build mikmod-mikmod/libmikmod -DENABLE_SHARED=0
 build jsoncpp -DBUILD_OBJECT_LIBS=OFF -DJSONCPP_WITH_TESTS=OFF -DJSONCPP_WITH_POST_BUILD_UNITTEST=OFF
+
+# gsKit is mandatory for SDL, gsKit doesn't have cmake configuration yet, however we are going to put it here to solve cycling dependencies
+make -C gsKit -j "$PROC_NR" install
 
 build SDL -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL_TESTS=OFF
 build SDL_mixer -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2MIXER_DEPS_SHARED=OFF -DSDL2MIXER_MOD_MODPLUG=ON -DSDL2MIXER_MIDI=OFF -DSDL2MIXER_FLAC=OFF -DSDL2MIXER_SAMPLES=OFF


### PR DESCRIPTION
This way, we can solve the circular dependencies we were suffering with `gsKit` and `ps2sdk-ports`.
Additionally we are also triggering a compilation to `gsKit` after a successfully `ps2sdk-ports` docker layer generated