### PR TITLE
add SIOCookie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer sdlttf unzip
+.PHONY: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay ode romfs sdl sdlgfx sdlimage sdlmixer sdlttf SIOCookie unzip
 
 all: libraries
-libraries: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf unzip
+libraries: aalib cmakelibs expat libconfig libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay romfs sdl sdlgfx sdlimage sdlmixer sdlttf SIOCookie unzip
 
 aalib:
 	$(MAKE) -C $@
@@ -102,6 +102,13 @@ sdlmixer: sdl
 
 sdlttf: sdl cmakelibs
 	$(MAKE) -C $@
+	$(MAKE) -C $@ install
+	$(MAKE) -C $@ clean
+
+SIOCookie:
+	rm -rf $@
+	git clone --depth 1 -b v1.0.0 https://github.com/israpps/SIOCookie
+	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean
 


### PR DESCRIPTION
# what's the purpose of `SIOCookie`?

> provide a simple way for developers to use EE SIO on newer toolchains without depending on `vsnprintf()`.
>
> This is achieved via `fopencookie()` (thanks @uyjulian  for the idea.)

# Why add it to ps2sdk-ports?

> on older toolchains developers only had to include `<sio.h>` and use `sio_printf()`
>
> the idea is to provide a similar system...
>
> and most importantly. skipping the hassle of adding the library to the project repo.
>
> where the developer just has to link the library, call a function to initialize both EE SIO and the custom stream to print on it, and then use `fprintf(EE_SIO, "blabla", blabla...);`


-----------

Since this is my first PR on ps2sdk-ports, please tell me if i have to adjust something to make the PR acceptable
