### PR TITLE
bump SIOCookie to `v1.0.1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ sdlttf: sdl cmakelibs
 
 SIOCookie:
 	rm -rf $@
-	git clone --depth 1 -b v1.0.0 https://github.com/israpps/SIOCookie
+	git clone --depth 1 -b v1.0.1 https://github.com/israpps/SIOCookie
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean


### PR DESCRIPTION
- avoids exposing `_GNU_SOURCE` macro on header file
- adds missing newline to the success message printed via serial port by the init function
- removes buffermode argumment from init, it is preferrable to enforce  `_IONBF`