### PR TITLE
Update SIOCookie to `v1.0.3`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ sdlttf: sdl cmakelibs
 
 SIOCookie:
 	rm -rf $@
-	git clone --depth 1 -b v1.0.1 https://github.com/israpps/SIOCookie
+	git clone --depth 1 -b v1.0.3 https://github.com/israpps/SIOCookie
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean


### PR DESCRIPTION
- uses line buffering instead of no buffering (only on std outputs, `EE_SIO` remains with `_IONBUF`
- also hooks `stderr`