### PR TITLE
update SIOCookie to v1.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ sdlttf: sdl cmakelibs
 
 SIOCookie:
 	rm -rf $@
-	git clone --depth 1 -b v1.0.1 https://github.com/israpps/SIOCookie
+	git clone --depth 1 -b v1.0.4 https://github.com/israpps/SIOCookie
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
 	$(MAKE) -C $@ clean


### PR DESCRIPTION
Enhancements:

- fixes format specifiers replacement on larger programs
- fixes buffering issue ([see here](https://github.com/israpps/SIOCookie/pull/2#issue-1660855588))
- also hook stderr
- when hooking std streams. only hook stdout and reassign `EE_SIO` and `stderr` as `stdout` because fopencookie does not seem to work when altering `stderr`