### PR TITLE
Update some libraries

### DIFF
--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -58,14 +58,8 @@ git clone --depth 1 -b 1.9.5 https://github.com/open-source-parsers/jsoncpp.git 
 pushd jsoncpp
 sed -i -e 's/std::snprintf/snprintf/' include/json/config.h
 popd
-# We need to clone the whole repo and point to the specific hash for now, 
-# till they release a new version with cmake compatibility
-git clone https://github.com/libxmp/libxmp.git || { exit 1; } 
-(cd libxmp && git checkout b0769774109d338554d534d9c122439d61d2bdd1 && cd -) || { exit 1; }
-# We need to clone the whole repo and point to the specific hash for now, 
-# till they release a new version with cmake compatibility
-git clone https://github.com/xiph/opus.git || { exit 1; } 
-(cd opus && git checkout ab04fbb1b7d0b727636d28fc2cadb5df9febe515 && cd -) || { exit 1; }
+git clone --depth 1 -b libxmp-4.6.0 https://github.com/libxmp/libxmp.git || { exit 1; } 
+git clone --depth 1 -b v1.4 https://github.com/xiph/opus.git || { exit 1; } 
 # We need to clone the whole repo and point to the specific hash for now, 
 # till they release a new version with cmake compatibility
 git clone https://github.com/xiph/opusfile.git || { exit 1; } 

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -83,7 +83,7 @@ git clone https://github.com/sezero/mikmod.git mikmod-mikmod || { exit 1; }
 git clone --depth 1 -b feature/cmake https://github.com/mcmtroffaes/theora.git || { exit 1; }
 
 # SDL requires to have gsKit
-git clone --depth 1 -b v1.3.5 https://github.com/ps2dev/gsKit || { exit 1; } 
+git clone --depth 1 -b v1.3.6 https://github.com/ps2dev/gsKit || { exit 1; } 
 
 # We need to clone the whole repo and point to the specific hash for now,
 # till a new version is released after this commit

--- a/libjpeg_ps2_addons/include/libjpg_ps2_addons.h
+++ b/libjpeg_ps2_addons/include/libjpg_ps2_addons.h
@@ -23,7 +23,6 @@ jpgData *jpgFromRAW(void *data, int size, int mode);
 jpgData *jpgFromFilename(const char *filename, int mode);
 jpgData *jpgFromFILE(FILE *in_file, int mode);
 void jpgFileFromJpgData(const char *filename, int quality, jpgData *jpg);
-int jpgScreenshot(const char* pFilename,unsigned int VramAdress, unsigned int Width, unsigned int Height, unsigned int Psm);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Description
This PR does some improvements:
- Remove `libdebug` dependency from `libjpg_ps2_addons` as the take screenshot functionality was used at all, neither OPL nor wLaunchELF and the main scope of that library was to bring retro-compatibility in OPL and wLE
- Update `gsKit` version
- Update `libxmp` version
- Update `opus` version