### PR TITLE
libjpg_ps2_addons: break dependency to libdebug ps2_screenshot()

### DIFF
--- a/libjpeg_ps2_addons/include/libjpg_ps2_addons.h
+++ b/libjpeg_ps2_addons/include/libjpg_ps2_addons.h
@@ -19,11 +19,13 @@ typedef struct {
 	void *buffer;
 } jpgData;
 
+typedef int cb_fetch_screen(void* pTemp, unsigned int VramAdress, unsigned int x, unsigned int y, unsigned int Width, unsigned int Height, unsigned int Psm);
+
 jpgData *jpgFromRAW(void *data, int size, int mode);
 jpgData *jpgFromFilename(const char *filename, int mode);
 jpgData *jpgFromFILE(FILE *in_file, int mode);
 void jpgFileFromJpgData(const char *filename, int quality, jpgData *jpg);
-int jpgScreenshot(const char* pFilename,unsigned int VramAdress, unsigned int Width, unsigned int Height, unsigned int Psm);
+int jpgScreenshot(const char* pFilename,unsigned int VramAdress, unsigned int Width, unsigned int Height, unsigned int Psm, cb_fetch_screen cb_fetch);
 
 #ifdef __cplusplus
 }

--- a/libjpeg_ps2_addons/src/libjpg_ps2_addons.c
+++ b/libjpeg_ps2_addons/src/libjpg_ps2_addons.c
@@ -9,7 +9,6 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <screenshot.h>
 #include <jpeglib.h>
 #include <setjmp.h>
 #include <gs_psm.h>
@@ -206,12 +205,15 @@ void jpgFileFromJpgData(const char *filename, int quality, jpgData *jpg) {
 	jpeg_destroy_compress(&cinfo);
 }
 
-int jpgScreenshot(const char* filename,unsigned int vramAdress, unsigned int width, unsigned int height, unsigned int psm)
+int jpgScreenshot(const char* filename,unsigned int vramAdress, unsigned int width, unsigned int height, unsigned int psm, cb_fetch_screen cb_fetch)
 {
 	int y;
 	static uint32_t in_buffer[1024*4];  // max 1024*32bit for a line, should be ok
 	uint8_t *p_out;
 	jpgData *jpg;
+
+	if (cb_fetch == NULL)
+		return -1;
 
 	jpg = malloc(sizeof(jpgData));
 	if(jpg == NULL)
@@ -228,7 +230,7 @@ int jpgScreenshot(const char* filename,unsigned int vramAdress, unsigned int wid
 	// Check if we have a tempbuffer, if we do we use it 
 	for (y = 0; y < height; y++)
 	{
-		ps2_screenshot(in_buffer, vramAdress, 0, y, width, 1, psm);
+		cb_fetch(in_buffer, vramAdress, 0, y, width, 1, psm);
 
 		if (psm == GS_PSM_16)
 		{


### PR DESCRIPTION
When APP/program links the `libjpg_ps2_addons` and does not use the `jpgScreenshot` function the APP still has to link `libdebug` because of hard dependency to `ps2_screenshot`. This simple change removes need of `libdebug`  dependency but user have to pass the pointer to `ps2_screenshot` manually to the `jpgScreenshot` call as a callback.