### PR TITLE
Fix building with GCC14

### DIFF
--- a/aalib/src/Makefile
+++ b/aalib/src/Makefile
@@ -52,7 +52,7 @@ $(EE_LIB_DIR):
 	mkdir -p $(EE_LIB_DIR)
 
 $(EE_OBJS_DIR)%.o : %.c
-	$(EE_C_COMPILE) -c $< -o $@
+	$(EE_C_COMPILE) -fpermissive -c $< -o $@
 
 install: all
 	mkdir -p $(DESTDIR)$(PS2SDK)/ports/include/

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -48,7 +48,7 @@ git clone --depth 1 -b v1.9.2 https://github.com/nih-at/libzip.git || { exit 1; 
 git clone --depth 1 -b v1.6.37 https://github.com/glennrp/libpng || { exit 1; }
 git clone --depth 1 -b VER-2-10-4 https://github.com/freetype/freetype || { exit 1; }
 git clone --depth 1 -b 0.2.5 https://github.com/yaml/libyaml || { exit 1; }
-git clone --depth 1 -b 2.1.0 https://github.com/libjpeg-turbo/libjpeg-turbo || { exit 1; }
+git clone --depth 1 -b 3.0.3 https://github.com/libjpeg-turbo/libjpeg-turbo || { exit 1; }
 git clone --depth 1 -b v1.3.5 https://github.com/xiph/ogg.git || { exit 1; }
 git clone --depth 1 -b v1.3.7 https://github.com/xiph/vorbis.git || { exit 1; }
 git clone --depth 1 -b v5.7.0-stable https://github.com/wolfSSL/wolfssl.git || { exit 1; }

--- a/libmad/ee/src/Makefile
+++ b/libmad/ee/src/Makefile
@@ -18,7 +18,7 @@ $(EE_LIB_DIR):
 	mkdir -p $(EE_LIB_DIR)
 
 $(EE_OBJS_DIR)%.o : %.c
-	$(EE_C_COMPILE) -c $< -o $@
+	$(EE_C_COMPILE) -fpermissive -c $< -o $@
 
 install: all
 	mkdir -p $(DESTDIR)$(PS2SDK)/ports/include

--- a/sdl/src/audio/ps2sdk/SDL_ps2audio.c
+++ b/sdl/src/audio/ps2sdk/SDL_ps2audio.c
@@ -34,6 +34,7 @@ static char rcsid =
 #include "SDL_ps2audio.h"
 #include <string.h>
 
+#include <malloc.h>
 #include <kernel.h>
 #include <sifrpc.h>
 #include <iopheap.h>

--- a/sdl/src/video/ps2sdk/SDL_ps2video.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2video.c
@@ -37,6 +37,7 @@
 #include "SDL_ps2USBevents.h"
 #include "SDL_ps2mouseevents.h"
 
+#include <malloc.h>
 #include <string.h>
 #include <gsKit.h>
 #include <dmaKit.h>


### PR DESCRIPTION
Fixes building issues with gcc14.

- For libmad / aalib: enable -permissive
- For SDL fix missing include properly
- Upgrade libjpeg-turbo

These seemed the easiest options.