### PR TITLE
Building over existing repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 #
 *_irx.c
 build/
+libconfuse/
 libtap/
 lua/
 ps2_drivers/

--- a/Makefile
+++ b/Makefile
@@ -1,152 +1,173 @@
-.PHONY: aalib cmakelibs expat libconfig libconfuse libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay ode ps2stuff ps2gl ps2_drivers romfs sdl sdlgfx sdlimage sdlmixer sdlttf SIOCookie unzip
+LIBS := \
+	aalib\
+	cmakelibs\
+	expat\
+	libconfig\
+	libconfuse\
+	libid3tag\
+	libjpeg_ps2_addons\
+	libmad\
+	libtap\
+	libtiff\
+	lua\
+	madplay\
+	ps2stuff\
+	ps2gl\
+	ps2_drivers\
+	romfs\
+	sdl\
+	sdlgfx\
+	sdlimag\
+	sdlmixer\
+	sdlttf\
+	SIOCookie\
+	unzip\
 
+LIBS_SAMPLES := \
+	aalib\
+	lua\
+
+# TODO: Broken samples
+# problem seems to be with the C strict mode
+# throwing warnings as errors
+#	sdl
+#	sdlgfx
+#	sdlmixer
+#	ode
+#	romfs
+
+.PHONY: $(LIBS)
 all: libraries
-libraries: aalib cmakelibs expat libconfig libconfuse libid3tag libjpeg_ps2_addons libmad libtap libtiff lua madplay ps2stuff ps2gl ps2_drivers romfs sdl sdlgfx sdlimage sdlmixer sdlttf SIOCookie unzip
+libraries: $(LIBS)
+
+$(addprefix clean-, $(LIBS)):
+	-$(MAKE) -C $(@:clean-%=%) clean
+
+$(addprefix sample-, $(LIBS_SAMPLES)): $(@:sample-%=%)
+	$(MAKE) -C $(@:sample-%=%) sample
+
+clean: $(addprefix clean-, $(LIBS))
+
+samples: $(addprefix sample-, $(LIBS_SAMPLES))
 
 aalib:
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 cmakelibs: ps2_drivers libtiff
 	./build-cmakelibs.sh
 
+clean-cmakelibs:
+	rm -rf ./build
+
 expat:
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 libconfig:
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 libconfuse:
-	rm -rf $@
-	git clone --depth 1 -b v3.3 https://github.com/libconfuse/libconfuse
+	./fetch.sh v3.3 https://github.com/libconfuse/libconfuse
 	cd $@ && ./autogen.sh
 	cd $@ && CFLAGS_FOR_TARGET="-G0 -O2 -gdwarf-2 -gz" ./configure --host=mips64r5900el-ps2-elf --prefix=$(PS2DEV)/portlibs/ps2 --disable-shared --disable-examples
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 libid3tag: cmakelibs
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 libjpeg_ps2_addons: cmakelibs
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 libmad: cmakelibs
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 libtap:
-	rm -rf $@
-	git clone --depth 1 https://github.com/ps2dev/libtap
+	./fetch.sh master https://github.com/ps2dev/libtap
 	$(MAKE) -C $@ -f Makefile.PS2 all
 	$(MAKE) -C $@ -f Makefile.PS2 install
-	$(MAKE) -C $@ -f Makefile.PS2 clean
+
+clean-libtap:
+	$(MAKE) -C libtap -f Makefile.PS2 clean
 
 libtiff:
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 lua:
-	rm -rf $@
-	git clone --depth 1 -b ee-v5.4.6 https://github.com/ps2dev/lua
+	./fetch.sh ee-v5.4.6 https://github.com/ps2dev/lua
 	$(MAKE) -C $@ all platform=PS2
 	$(MAKE) -C $@ install platform=PS2
-	$(MAKE) -C $@ clean platform=PS2
+
+clean-lua:
+	$(MAKE) -C lua clean platform=PS2
+
+sample-lua:
+	$(MAKE) -C lua sample platform=PS2
 
 # depends on SjPCM sound library
 madplay: cmakelibs libid3tag libmad
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 # depends on dream2gl and ps2Perf
 # Broken
 ode:
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 ps2_drivers:
-	rm -rf $@
-	git clone --depth 1 -b 1.6.2 https://github.com/fjtrujy/ps2_drivers
+	./fetch.sh 1.6.2 https://github.com/fjtrujy/ps2_drivers
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 ps2stuff:
-	rm -rf $@
-	git clone --depth 1 https://github.com/ps2dev/ps2stuff
+	./fetch.sh master https://github.com/ps2dev/ps2stuff
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 ps2gl: ps2stuff
-	rm -rf $@
-	git clone --depth 1 https://github.com/ps2dev/ps2gl
+	./fetch.sh master https://github.com/ps2dev/ps2gl
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
-	$(MAKE) -C $@/glut install 
-	$(MAKE) -C $@/glut clean
- 
+	$(MAKE) -C $@/glut install
+
+clean-ps2gl:
+	$(MAKE) -C ps2gl clean
+	$(MAKE) -C ps2gl/glut clean
 
 romfs:
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 sdl: cmakelibs
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 sdlgfx: sdlimage
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 sdlimage: cmakelibs libtiff sdl
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 sdlmixer: sdl
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 sdlttf: sdl cmakelibs
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 SIOCookie:
-	rm -rf $@
-	git clone --depth 1 -b v1.0.4 https://github.com/israpps/SIOCookie
+	./fetch.sh v1.0.4 https://github.com/israpps/SIOCookie
 	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
 
 unzip: cmakelibs
 	$(MAKE) -C $@
 	$(MAKE) -C $@ install
-	$(MAKE) -C $@ clean
-
-sample: aalib sdl sdlgfx sdlmixer lua ode romfs
-	$(MAKE) -C aalib sample
-	$(MAKE) -C sdl sample
-	$(MAKE) -C sdlgfx sample
-	$(MAKE) -C sdlmixer sample
-	$(MAKE) -C lua sample platform=PS2
-# Broken samples
-#	$(MAKE) -C ode sample
-#	$(MAKE) -C romfs sample

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -118,7 +118,7 @@ $FETCH v3.2.2.f25c624 https://github.com/argtable/argtable3.git
 ##
 ## Build cmake projects
 ##
-PROC_NR=1 build zlib -DUNIX:BOOL=ON # Forcing to compile with -j1 because there is a race condition in zlib
+PROC_NR=1 build zlib -DUNIX:BOOL=ON -DZLIB_BUILD_EXAMPLES=OFF # Forcing to compile with -j1 because there is a race condition in zlib
 build xz -DTUKLIB_CPUCORES_FOUND=ON -DTUKLIB_PHYSMEM_FOUND=ON -DHAVE_GETOPT_LONG=OFF -DBUILD_TESTING=OFF
 build lz4/build/cmake -DLZ4_POSITION_INDEPENDENT_LIB=OFF -DLZ4_BUILD_CLI=OFF -DLZ4_BUILD_LEGACY_LZ4C=OFF
 build libzip -DBUILD_TOOLS=OFF -DBUILD_REGRESS=OFF

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -118,7 +118,7 @@ $FETCH v3.2.2.f25c624 https://github.com/argtable/argtable3.git
 ##
 ## Build cmake projects
 ##
-PROC_NR=1 build zlib -DUNIX:BOOL=ON -DZLIB_BUILD_EXAMPLES=OFF # Forcing to compile with -j1 because there is a race condition in zlib
+build zlib -DUNIX:BOOL=ON -DZLIB_BUILD_EXAMPLES=OFF
 build xz -DTUKLIB_CPUCORES_FOUND=ON -DTUKLIB_PHYSMEM_FOUND=ON -DHAVE_GETOPT_LONG=OFF -DBUILD_TESTING=OFF
 build lz4/build/cmake -DLZ4_POSITION_INDEPENDENT_LIB=OFF -DLZ4_BUILD_CLI=OFF -DLZ4_BUILD_LEGACY_LZ4C=OFF
 build libzip -DBUILD_TOOLS=OFF -DBUILD_REGRESS=OFF

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -63,7 +63,7 @@ $FETCH v1.3.1 https://github.com/madler/zlib
 $FETCH v5.4.0 https://github.com/xz-mirror/xz.git
 $FETCH v1.9.4 https://github.com/lz4/lz4.git
 $FETCH v1.9.2 https://github.com/nih-at/libzip.git
-$FETCH v1.6.37 https://github.com/glennrp/libpng
+$FETCH v1.6.43 https://github.com/glennrp/libpng
 $FETCH VER-2-10-4 https://github.com/freetype/freetype
 $FETCH v1.14.0 https://github.com/google/googletest
 $FETCH 0.2.5 https://github.com/yaml/libyaml

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -59,7 +59,7 @@ cd build
 ##
 ## Clone repos
 ##
-$FETCH v1.2.12 https://github.com/madler/zlib
+$FETCH v1.3.1 https://github.com/madler/zlib
 $FETCH v5.4.0 https://github.com/xz-mirror/xz.git
 $FETCH v1.9.4 https://github.com/lz4/lz4.git
 $FETCH v1.9.2 https://github.com/nih-at/libzip.git

--- a/build-cmakelibs.sh
+++ b/build-cmakelibs.sh
@@ -59,61 +59,68 @@ cd build
 ##
 ## Clone repos
 ##
-$FETCH v1.3.1 https://github.com/madler/zlib
-$FETCH v5.4.0 https://github.com/xz-mirror/xz.git
-$FETCH v1.9.4 https://github.com/lz4/lz4.git
-$FETCH v1.9.2 https://github.com/nih-at/libzip.git
-$FETCH v1.6.43 https://github.com/glennrp/libpng
-$FETCH VER-2-10-4 https://github.com/freetype/freetype
-$FETCH v1.14.0 https://github.com/google/googletest
-$FETCH 0.2.5 https://github.com/yaml/libyaml
-$FETCH 3.0.3 https://github.com/libjpeg-turbo/libjpeg-turbo
-$FETCH v1.3.5 https://github.com/xiph/ogg.git
-$FETCH v1.3.7 https://github.com/xiph/vorbis.git
-$FETCH v5.7.0-stable https://github.com/wolfSSL/wolfssl.git
-$FETCH curl-8_7_1 https://github.com/curl/curl.git
-$FETCH 1.9.5 https://github.com/open-source-parsers/jsoncpp.git
+$FETCH v1.3.1 https://github.com/madler/zlib &
+$FETCH v5.4.0 https://github.com/xz-mirror/xz.git &
+$FETCH v1.9.4 https://github.com/lz4/lz4.git &
+$FETCH v1.9.2 https://github.com/nih-at/libzip.git &
+$FETCH v1.6.43 https://github.com/glennrp/libpng &
+$FETCH VER-2-10-4 https://github.com/freetype/freetype &
+$FETCH v1.14.0 https://github.com/google/googletest &
+$FETCH 0.2.5 https://github.com/yaml/libyaml &
+$FETCH 3.0.3 https://github.com/libjpeg-turbo/libjpeg-turbo &
+$FETCH v1.3.5 https://github.com/xiph/ogg.git &
+$FETCH v1.3.7 https://github.com/xiph/vorbis.git &
+$FETCH v5.7.0-stable https://github.com/wolfSSL/wolfssl.git &
+$FETCH curl-8_7_1 https://github.com/curl/curl.git &
+$FETCH 1.9.5 https://github.com/open-source-parsers/jsoncpp.git &
+$FETCH libxmp-4.6.0 https://github.com/libxmp/libxmp.git &
+$FETCH v1.4 https://github.com/xiph/opus.git &
+# We need to clone the whole repo and point to the specific hash for now,
+# till they release a new version with cmake compatibility
+# we need to clone whole repo because it uses `git describe --tags` for version info
+$FETCH cf218fb54929a1f54e30e2cb208a22d08b08c889 https://github.com/xiph/opusfile.git true &
+# We need to clone the whole repo and point to the specific hash for now,
+# till they release a new version with cmake compatibility
+$FETCH d1b97ed0020bc620a059d3675d1854b40bd2608d https://github.com/Konstanty/libmodplug.git &
+# We need to clone the whole repo and point to the specific hash for now,
+# till they release a new version with cmake compatibility
+$FETCH 096d0711ca3e294564a5c6ec18f5bbc3a2aac016 https://github.com/sezero/mikmod.git &
+# We need to clone a fork, this is a PR opened for ading cmake support
+# https://github.com/xiph/theora/pull/14
+$FETCH feature/cmake https://github.com/mcmtroffaes/theora.git &
+
+# SDL requires to have gsKit
+$FETCH v1.3.7 https://github.com/ps2dev/gsKit &
+
+# We need to clone the whole repo and point to the specific hash for now,
+# till a new version is released after this commit
+$FETCH 10c14e78b650e626293aa18155efec54cdee7098 https://github.com/libsdl-org/SDL.git &
+$FETCH release-2.6.3 https://github.com/libsdl-org/SDL_mixer.git &
+$FETCH release-2.6.3 https://github.com/libsdl-org/SDL_image.git &
+$FETCH release-2.20.2 https://github.com/libsdl-org/SDL_ttf.git &
+
+# We need to clone the whole repo and point to the specific hash for now,
+# till a new version is released after this commit
+$FETCH dccf1dbccd66a8c433e336de4951a249096e1c22 https://github.com/sahlberg/libsmb2.git &
+# We need to clone the whole repo and point to the specific hash for now,
+# till a new version is released after this commit
+$FETCH 7083138fd401faa391c4f829a86b50fdb9c5c727 https://github.com/lsalzman/enet.git &
+
+# Use wget to download argtable2
+wget -c http://prdownloads.sourceforge.net/argtable/argtable2-13.tar.gz &
+$FETCH v3.2.2.f25c624 https://github.com/argtable/argtable3.git &
+
+# wait for fetch jobs to finish
+wait
+
+# extract argtable2
+tar -xzf argtable2-13.tar.gz
+
+# NOTE: jsoncpp
 # "snprintf" not found in "std" namespace error may occur, so patch that out here.
 pushd jsoncpp
 sed -i -e 's/std::snprintf/snprintf/' include/json/config.h
 popd
-$FETCH libxmp-4.6.0 https://github.com/libxmp/libxmp.git
-$FETCH v1.4 https://github.com/xiph/opus.git
-# We need to clone the whole repo and point to the specific hash for now,
-# till they release a new version with cmake compatibility
-# we need to clone whole repo because it uses `git describe --tags` for version info
-$FETCH cf218fb54929a1f54e30e2cb208a22d08b08c889 https://github.com/xiph/opusfile.git true
-# We need to clone the whole repo and point to the specific hash for now,
-# till they release a new version with cmake compatibility
-$FETCH d1b97ed0020bc620a059d3675d1854b40bd2608d https://github.com/Konstanty/libmodplug.git
-# We need to clone the whole repo and point to the specific hash for now,
-# till they release a new version with cmake compatibility
-$FETCH 096d0711ca3e294564a5c6ec18f5bbc3a2aac016 https://github.com/sezero/mikmod.git
-# We need to clone a fork, this is a PR opened for ading cmake support
-# https://github.com/xiph/theora/pull/14
-$FETCH feature/cmake https://github.com/mcmtroffaes/theora.git
-
-# SDL requires to have gsKit
-$FETCH v1.3.7 https://github.com/ps2dev/gsKit
-
-# We need to clone the whole repo and point to the specific hash for now,
-# till a new version is released after this commit
-$FETCH 10c14e78b650e626293aa18155efec54cdee7098 https://github.com/libsdl-org/SDL.git
-$FETCH release-2.6.3 https://github.com/libsdl-org/SDL_mixer.git
-$FETCH release-2.6.3 https://github.com/libsdl-org/SDL_image.git
-$FETCH release-2.20.2 https://github.com/libsdl-org/SDL_ttf.git
-
-# We need to clone the whole repo and point to the specific hash for now,
-# till a new version is released after this commit
-$FETCH dccf1dbccd66a8c433e336de4951a249096e1c22 https://github.com/sahlberg/libsmb2.git
-# We need to clone the whole repo and point to the specific hash for now,
-# till a new version is released after this commit
-$FETCH 7083138fd401faa391c4f829a86b50fdb9c5c727 https://github.com/lsalzman/enet.git
-
-# Use wget to download argtable2
-wget -c http://prdownloads.sourceforge.net/argtable/argtable2-13.tar.gz
-tar -xzf argtable2-13.tar.gz
-$FETCH v3.2.2.f25c624 https://github.com/argtable/argtable3.git
 
 ##
 ## Build cmake projects

--- a/fetch.sh
+++ b/fetch.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+REPO_REF="$1"
+REPO_URL="$2"
+FETCH_ALL="$3"
+REPO_FOLDER=$(basename "$REPO_URL")
+REPO_FOLDER=${REPO_FOLDER%.*}
+echo "Fetching '$REPO_FOLDER' version '$REPO_REF'..."
+if [ ! -d "$REPO_FOLDER" ]; then
+    git init "$REPO_FOLDER"
+    git -C "$REPO_FOLDER" remote add origin "$REPO_URL"
+else
+    git -C "$REPO_FOLDER" remote set-url origin "$REPO_URL"
+fi
+if [[ "$FETCH_ALL" == true ]]; then
+    git -C "$REPO_FOLDER" fetch --unshallow || true
+    git -C "$REPO_FOLDER" fetch origin "$REPO_REF" --tags
+else
+    git -C "$REPO_FOLDER" fetch origin "$REPO_REF" --depth=1
+fi
+git -C "$REPO_FOLDER" checkout -f FETCH_HEAD


### PR DESCRIPTION
The original did not work when the build directory for sub-dependency already existed and I did not want to remove all the packages, so I changed the script that it now could download the repos when they are already exist.

I have also updated libpng and zlib to try if the zlib parallel build works. It worked for me, but I suggest more testing of that.

Also check  [#641](https://github.com/ps2dev/ps2sdk/pull/641)