### PR TITLE
Update to the latest PS2 Drivers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ ode:
 	$(MAKE) -C $@ install
 
 ps2_drivers:
-	./fetch.sh 1.6.3 https://github.com/fjtrujy/ps2_drivers
+	./fetch.sh 1.6.4 https://github.com/fjtrujy/ps2_drivers
 	$(MAKE) -C build/$@ all
 	$(MAKE) -C build/$@ install
 


### PR DESCRIPTION
This upgrade is necessary because the unloading of IRX wasn't working properly.