### PR TITLE
Sdl sane iop

### DIFF
--- a/sdl/src/Makefile
+++ b/sdl/src/Makefile
@@ -21,8 +21,17 @@ USE_FREESIO2=1
 EE_CFLAGS  = -DNO_SIGNAL_H -DDEBUG_ERROR -DUSE_MATH_H
 EE_CFLAGS += -DENABLE_PS2SDK
 
-ifeq ($(ENABLE_MTAP), 1)
-EE_CFLAGS += -DPS2SDL_ENABLE_MTAP
+# surrender all IOP handling to the program using this library. granting full control of the IOP, and not forcing usage of specific modules
+# Very useful for special cases, like Supporting arcade PS2s, or... just trying to do things right
+ifeq ($(NO_IOP_HANDLING), 1)
+  EE_CFLAGS += -DNO_IOP_HANDLING
+  ifeq ($(ENABLE_MTAP), 1)
+  EE_CFLAGS += -DPS2SDL_ENABLE_MTAP
+  endif
+  
+  ifeq ($(USE_FREESIO2), 1)
+  EE_CFLAGS += -DUSE_FREESIO2
+  endif
 endif
 
 ifeq ($(HAVE_INPUT_DEVICES), 1)
@@ -31,10 +40,6 @@ endif
 
 ifeq ($(USE_FREESD), 1)
 EE_CFLAGS += -DUSE_FREESD
-endif
-
-ifeq ($(USE_FREESIO2), 1)
-EE_CFLAGS += -DUSE_FREESIO2
 endif
 
 ifeq ($(ENABLE_VSYNC_CB), 1)
@@ -150,24 +155,29 @@ video/ps2sdk/ps2usbd_irx.c: $(PS2SDK)/iop/irx/usbd.irx
 	$(PS2SDK)/bin/bin2c $< $@ ps2usbd_irx
 
 
-ifeq ($(ENABLE_MTAP), 1)
-EMBEDDED = \
-	$(PS2SDK)/ee/lib/libpadx.a           \
-	$(PS2SDK)/ee/lib/libmtap.a
-else
-EMBEDDED = \
-	$(PS2SDK)/ee/lib/libpad.a
+ifeq ($(NO_IOP_HANDLING), 1)
+  ifeq ($(ENABLE_MTAP), 1)
+  EMBEDDED = \
+  	$(PS2SDK)/ee/lib/libpadx.a \
+  	$(PS2SDK)/ee/lib/libmtap.a
+  else
+  EMBEDDED = \
+  	$(PS2SDK)/ee/lib/libpad.a
+  endif
 endif
 
 EMBEDDED += \
 	$(PS2SDK)/ee/lib/libcdvd.a	\
-	$(PS2SDK)/ee/lib/libpatches.a       \
-	$(PS2SDK)/ee/lib/libkbd.a       \
-	$(PS2SDK)/ee/lib/libmouse.a     \
-	$(PS2SDK)/ee/lib/libaudsrv.a    \
-	$(PS2SDK)/ports/lib/libjpeg.a    \
-	$(GSKIT)/lib/libdmakit.a	\
+	$(PS2SDK)/ee/lib/libpatches.a \
+	$(PS2SDK)/ee/lib/libaudsrv.a \
+	$(PS2SDK)/ports/lib/libjpeg.a \
+	$(GSKIT)/lib/libdmakit.a \
 	$(GSKIT)/lib/libgskit.a
+
+ifeq ($(HAVE_INPUT_DEVICES), 1)
+  EMBEDDED += $(PS2SDK)/ee/lib/libkbd.a \
+    $(PS2SDK)/ee/lib/libmouse.a
+endif
 
 $(LIB_SDL): $(SDL_OBJS)
 	# packing with all embedded libraries

--- a/sdl/src/Makefile
+++ b/sdl/src/Makefile
@@ -18,6 +18,10 @@ USE_FREESD=1
 # Enable FREESIO2 instead of XSIO2MAN
 USE_FREESIO2=1
 
+# surrender all IOP handling to the program using this library. granting full control of the IOP, and not forcing usage of specific modules
+# Very useful for special cases, like Supporting arcade PS2s, or... just trying to do things right
+NO_IOP_HANDLING=0
+
 EE_CFLAGS  = -DNO_SIGNAL_H -DDEBUG_ERROR -DUSE_MATH_H
 EE_CFLAGS += -DENABLE_PS2SDK
 

--- a/sdl/src/audio/ps2sdk/SDL_ps2audio.c
+++ b/sdl/src/audio/ps2sdk/SDL_ps2audio.c
@@ -55,7 +55,7 @@ static int spu2_init()
 	int error;
 
 	SifInitRpc(0);
-
+#ifndef NO_IOP_HANDLING
 #ifdef USE_FREESD
 	// load freesd (libsd replacement)
 	SifExecModuleBuffer(&freesd_irx, size_freesd_irx, 0, NULL, &error);
@@ -77,7 +77,7 @@ static int spu2_init()
 		SDL_SetError("Failed to load audsrv module");
 		return -1;
 	}
-
+#endif
 	/* init audsrv */
 	audsrv_init();
 

--- a/sdl/src/audio/ps2sdk/SDL_ps2audio.c
+++ b/sdl/src/audio/ps2sdk/SDL_ps2audio.c
@@ -52,27 +52,27 @@ extern unsigned char audsrv_irx;
 
 static int spu2_init()
 {
-	int error;
+	int id, ret;
 
 	SifInitRpc(0);
 #ifndef NO_IOP_HANDLING
 #ifdef USE_FREESD
 	// load freesd (libsd replacement)
-	SifExecModuleBuffer(&freesd_irx, size_freesd_irx, 0, NULL, &error);
-    	if (error < 0)
-    	{
+	id = SifExecModuleBuffer(&freesd_irx, size_freesd_irx, 0, NULL, &ret);
+    if (id < 0 || ((ret & 3) != 0))
+    {
 		SDL_SetError("Failed to load FREESD module");
-    	}
+    }
 #else
-	error = SifLoadModule("rom0:LIBSD", 0, NULL);
-	if (error < 0)
+	id = SifLoadStartModule("rom0:LIBSD", 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to open LIBSD module");
 		return -1;
 	}
 #endif
-	SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL, &error);
-	if (error < 0)
+	id = SifExecModuleBuffer(&audsrv_irx, size_audsrv_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load audsrv module");
 		return -1;

--- a/sdl/src/joystick/ps2sdk/ps2joystick.c
+++ b/sdl/src/joystick/ps2sdk/ps2joystick.c
@@ -152,7 +152,7 @@ int SDL_SYS_JoystickInit(void)
 	int port, slot;
 
 	printf("SDL_Joystick: JoystickInit begins\n");
-
+#ifndef NO_IOP_HANDLING
 #ifdef PS2SDL_ENABLE_MTAP
 #ifdef USE_FREESIO2
 	SifExecModuleBuffer(sio2man_irx, size_sio2man_irx, 0, NULL, &ret);
@@ -212,11 +212,12 @@ int SDL_SYS_JoystickInit(void)
 		return 0;
 	}
 #endif
+#endif
 
 	ret = padInit(0);
 	printf("SDL_Joystick: padInit: %d\n", ret);
 
-#ifdef PS2SDL_ENABLE_MTAP
+#if defined(PS2SDL_ENABLE_MTAP) && !defined(NO_IOP_HANDLING)
 	ret = mtapInit();
 	printf("SDL_Joystick: mtapInit: %d\n", ret);
 #endif

--- a/sdl/src/joystick/ps2sdk/ps2joystick.c
+++ b/sdl/src/joystick/ps2sdk/ps2joystick.c
@@ -145,7 +145,7 @@ static int wait_pad(int port, int slot, int tries)
  */
 int SDL_SYS_JoystickInit(void)
 {
-	int ret;
+	int ret, id;
 	int mtap_enabled;
 	int index;
 	int numports, numdevs;
@@ -155,58 +155,58 @@ int SDL_SYS_JoystickInit(void)
 #ifndef NO_IOP_HANDLING
 #ifdef PS2SDL_ENABLE_MTAP
 #ifdef USE_FREESIO2
-	SifExecModuleBuffer(sio2man_irx, size_sio2man_irx, 0, NULL, &ret);
-	if (ret < 0)
+	id = SifExecModuleBuffer(sio2man_irx, size_sio2man_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load SIO2MAN");
 		return 0;
 	}
 
-	SifExecModuleBuffer(padman_irx, size_padman_irx, 0, NULL, &ret);
-	if (ret < 0)
+	id = SifExecModuleBuffer(padman_irx, size_padman_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load PADMAN");
 		return 0;
 	}
 
-	SifExecModuleBuffer(mtapman_irx, size_mtapman_irx, 0, NULL, &ret);
-	if (ret < 0)
+	id = SifExecModuleBuffer(mtapman_irx, size_mtapman_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load MTAPMAN");
 		return 0;
 	}
 #else
-	ret = SifLoadModule("rom0:XSIO2MAN", 0, NULL);
-	if (ret < 0)
+	id = SifLoadStartModule("rom0:XSIO2MAN", 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load XSIO2MAN");
 		return 0;
 	}
 
-	ret = SifLoadModule("rom0:XPADMAN", 0, NULL);
-	if (ret < 0)
+	id = SifLoadStartModule("rom0:XPADMAN", 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load XPADMAN");
 		return 0;
 	}
 
-	ret = SifLoadModule("rom0:XMTAPMAN", 0, NULL);
-	if (ret < 0)
+	id = SifLoadStartModule("rom0:XMTAPMAN", 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load XMTAPMAN");
 		return 0;
 	}
 #endif
 #else
-	ret = SifLoadModule("rom0:SIO2MAN", 0, NULL);
-	if (ret < 0)
+	ret = SifLoadStartModule("rom0:SIO2MAN", 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load SIO2MAN");
 		return 0;
 	}
 
-	ret = SifLoadModule("rom0:PADMAN", 0, NULL);
-	if (ret < 0)
+	ret = SifLoadStartModule("rom0:PADMAN", 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("Failed to load PADMAN");
 		return 0;

--- a/sdl/src/main/ps2sdk/sdl_main.c
+++ b/sdl/src/main/ps2sdk/sdl_main.c
@@ -18,7 +18,7 @@ int SDL_HasMMX()
 #undef main
 int main(int argc, char *argv[])
 {
-#ifdef PS2SDL_ENABLE_MTAP
+#if defined(PS2SDL_ENABLE_MTAP) && !defined(NO_IOP_HANDLING)
 	SifInitRpc(0);
 
 	smod_mod_info_t info;

--- a/sdl/src/video/ps2sdk/SDL_ps2USBevents.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2USBevents.c
@@ -44,14 +44,14 @@ int PS2_InitUSB(_THIS)
 	int ret;
     
 	printf("[PS2] Init USB driver\n");
-
+#ifndef NO_IOP_HANDLING
 	SifExecModuleBuffer(ps2usbd_irx, size_ps2usbd_irx, 0, NULL, &ret);
 	if (ret < 0) 
 	{
 		SDL_SetError("[PS2] Failed to load module: usbd_irx\n");
 		return -1;
 	}  
-    
+#endif 
 	usbState = USB_AVAILABLE;
     
 	printf("[PS2] Init USB driver done\n");

--- a/sdl/src/video/ps2sdk/SDL_ps2USBevents.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2USBevents.c
@@ -45,8 +45,8 @@ int PS2_InitUSB(_THIS)
     
 	printf("[PS2] Init USB driver\n");
 #ifndef NO_IOP_HANDLING
-	SifExecModuleBuffer(ps2usbd_irx, size_ps2usbd_irx, 0, NULL, &ret);
-	if (ret < 0) 
+	id = SifExecModuleBuffer(ps2usbd_irx, size_ps2usbd_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("[PS2] Failed to load module: usbd_irx\n");
 		return -1;

--- a/sdl/src/video/ps2sdk/SDL_ps2kbdevents.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2kbdevents.c
@@ -352,13 +352,13 @@ void PS2_InitOSKeymap(_THIS)
  */
 int PS2_InitKeyboard(_THIS){
     
-    int ret;
+    int ret, id;
     
     printf("[PS2] Init USB Keyboard\n");
 #ifndef NO_IOP_HANDLING
     // the keyboard driver is embedded in the library....
-    SifExecModuleBuffer(ps2kbd_irx, size_ps2kbd_irx, 0, NULL, &ret);
-    if (ret < 0) {
+    id = SifExecModuleBuffer(ps2kbd_irx, size_ps2kbd_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
            SDL_SetError("[PS2] Failed to load module: ps2kbd_irx\n");
            return -1;
     } 

--- a/sdl/src/video/ps2sdk/SDL_ps2kbdevents.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2kbdevents.c
@@ -355,15 +355,16 @@ int PS2_InitKeyboard(_THIS){
     int ret;
     
     printf("[PS2] Init USB Keyboard\n");
-    
+#ifndef NO_IOP_HANDLING
     // the keyboard driver is embedded in the library....
     SifExecModuleBuffer(ps2kbd_irx, size_ps2kbd_irx, 0, NULL, &ret);
     if (ret < 0) {
            SDL_SetError("[PS2] Failed to load module: ps2kbd_irx\n");
            return -1;
     } 
-    else {
-    
+    else
+#endif
+	{
         if((PS2KbdInit()) == 0) {
             SDL_SetError("[PS2] PS2KbdInit failed\n");
             kbdState = KBD_NOT_AVAILABLE;

--- a/sdl/src/video/ps2sdk/SDL_ps2mouseevents.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2mouseevents.c
@@ -88,7 +88,7 @@ int PS2_InitMouse(_THIS)
 	int ret;
 
 	printf("[PS2] Init USB Mouse\n");
-
+#ifndef NO_IOP_HANDLING
 	// the mouse driver is embedded in the library....
 	SifExecModuleBuffer(ps2mouse_irx, size_ps2mouse_irx, 0, NULL, &ret);
 	if (ret < 0)
@@ -107,6 +107,7 @@ int PS2_InitMouse(_THIS)
 		return -1;
 	}
 	else
+#endif
 	{
 		// Initialize the mouse
 		if(PS2MouseInit() < 0) 

--- a/sdl/src/video/ps2sdk/SDL_ps2mouseevents.c
+++ b/sdl/src/video/ps2sdk/SDL_ps2mouseevents.c
@@ -90,8 +90,8 @@ int PS2_InitMouse(_THIS)
 	printf("[PS2] Init USB Mouse\n");
 #ifndef NO_IOP_HANDLING
 	// the mouse driver is embedded in the library....
-	SifExecModuleBuffer(ps2mouse_irx, size_ps2mouse_irx, 0, NULL, &ret);
-	if (ret < 0)
+	id = SifExecModuleBuffer(ps2mouse_irx, size_ps2mouse_irx, 0, NULL, &ret);
+	if (id < 0 || ((ret & 3) != 0))
 	{
 		SDL_SetError("[PS2] Failed to load module: PS2MOUSE.IRX\n");
 


### PR DESCRIPTION
[allow SDL to be built without IOP handling](https://github.com/ps2dev/ps2sdk-ports/commit/af26d610fc2caaaff36854ce783a7f2d8263295d)
new make variable `NO_IOP_HANDLING` will disable features that have influence over the iop, such as loading modules and rebooting the IOP

The RPC EE servers remain bc they are obviously needed

***

[Fix IRX return value check on SDL](https://github.com/ps2dev/ps2sdk-ports/commit/5a1255ba9b6201a88dda2a74daeb0b837217fc1b) 

Module ID being less <= 0 means that MODLOAD returned an error (see `kerr.h`)

Now, for the module return value...

`((ret & 3) != 0)` is the condition used by `rom0:MODLOAD` to check if module requested to be unloaded from it's main function (eg: aborted startup, whatever...). newer modloads use a different (and not backwards compatible) logic. so this new logic will work as intended as long as the program using this library did not replace the MODLOAD module with one that supports unloading...

This is MUCH better than the old flawed logic. since SDL will no longer deem a module returning `MODULE_NO_RESIDENT_END` as successfully executed